### PR TITLE
feat: add top bar layout with settings icon

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import TopBar from './components/TopBar'
 
 function App() {
   const [msg, setMsg] = useState('cargando...')
@@ -11,10 +12,13 @@ function App() {
   }, [])
 
   return (
-    <div style={{fontFamily:'system-ui, sans-serif', padding: 24}}>
-      <h1>MP3 Tool</h1>
-      <p>Backend dice: <strong>{msg}</strong></p>
-    </div>
+    <>
+      <TopBar />
+      <div style={{fontFamily:'system-ui, sans-serif', padding: 24}}>
+        <h1>MP3 Tool</h1>
+        <p>Backend dice: <strong>{msg}</strong></p>
+      </div>
+    </>
   )
 }
 

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -1,0 +1,33 @@
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 48px;
+  padding: 0 16px;
+  background-color: #1f1f1f;
+  color: #ffffff;
+}
+
+.topbar__logo {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #333333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.topbar__settings {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.topbar__settings svg {
+  width: 24px;
+  height: 24px;
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+import './TopBar.css'
+
+interface TopBarProps {
+  logo?: ReactNode
+}
+
+const TopBar = ({ logo }: TopBarProps) => {
+  return (
+    <header className="topbar">
+      <div className="topbar__logo">{logo}</div>
+      <button className="topbar__settings" aria-label="Abrir configuración">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M11.983 2.083a1 1 0 0 1 1.935 0l.342 1.094a1 1 0 0 0 .95.694h1.154a1 1 0 0 1 .986 1.164l-.223 1.274a1 1 0 0 0 .271.907l.817.817a1 1 0 0 1 0 1.414l-.817.817a1 1 0 0 0-.271.907l.223 1.274a1 1 0 0 1-.986 1.164h-1.154a1 1 0 0 0-.95.694l-.342 1.094a1 1 0 0 1-1.935 0l-.342-1.094a1 1 0 0 0-.95-.694H9.537a1 1 0 0 1-.986-1.164l.223-1.274a1 1 0 0 0-.271-.907l-.817-.817a1 1 0 0 1 0-1.414l.817-.817a1 1 0 0 0 .271-.907L8.55 5.035A1 1 0 0 1 9.537 3.87h1.154a1 1 0 0 0 .95-.694l.342-1.094zM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" clipRule="evenodd" />
+        </svg>
+      </button>
+    </header>
+  )
+}
+
+export default TopBar


### PR DESCRIPTION
## Summary
- add TopBar component with placeholder logo and gear icon
- render top bar in main app layout
- support custom logo prop for future customization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68adb82efb788332a3c27273df264edd