### PR TITLE
fix: run vite via shell to avoid spawn error

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -38,10 +38,18 @@ function startPython() {
 
 function startVite(onReady) {
     const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-    viteProc = spawn(npmCmd, ["run", "dev"], {
-        cwd: path.join(__dirname, "..", "frontend"),
-        env: { ...process.env },
-    });
+    try {
+        viteProc = spawn(npmCmd, ["run", "dev"], {
+            cwd: path.join(__dirname, "..", "frontend"),
+            env: { ...process.env },
+            shell: true,
+        });
+    } catch (err) {
+        console.error("[VITE] failed to start:", err);
+        return;
+    }
+
+    viteProc.on("error", (err) => console.error("[VITE]", err));
 
     viteProc.stdout.on("data", (d) => {
         const text = d.toString();


### PR DESCRIPTION
## Summary
- run Vite dev server through a shell so `npm run dev` starts reliably
- guard Vite startup with try/catch and log spawn errors

## Testing
- `cd desktop && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68adc76202c48332bf0e2ed9e32865a3