### PR TITLE
fix: ensure top bar spans full width and hide default menu

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,5 +1,5 @@
 // desktop/main.js
-const { app, BrowserWindow, dialog } = require("electron");
+const { app, BrowserWindow, dialog, Menu } = require("electron");
 const path = require("path");
 const { spawn } = require("child_process");
 const kill = require("tree-kill");
@@ -166,6 +166,7 @@ function createWindow() {
 }
 
 app.whenReady().then(async () => {
+    Menu.setApplicationMenu(null);
     // 1) Arranca backend + espera puerto
     startPython();
     try {

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -6,6 +6,7 @@
   padding: 0 16px;
   background-color: #1f1f1f;
   color: #ffffff;
+  width: 100%;
 }
 
 .topbar__logo {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,10 +24,12 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+}
+
+#root {
+  width: 100%;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- remove centering styles so top bar sits at top and uses full width
- drop Electron's default menu bar during startup

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm test` (desktop, fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_b_68ae0cb6892083329772225343969e12