### PR TITLE
feat: dark theme with input boxes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,9 +14,15 @@ function App() {
   return (
     <>
       <TopBar />
-      <div style={{fontFamily:'system-ui, sans-serif', padding: 24}}>
+      <div style={{ fontFamily: 'system-ui, sans-serif', padding: 24 }}>
         <h1>MP3 Tool</h1>
-        <p>Backend dice: <strong>{msg}</strong></p>
+        <p>
+          Backend dice: <strong>{msg}</strong>
+        </p>
+        <div className="text-boxes">
+          <input type="text" placeholder="Caja 1" />
+          <input type="text" placeholder="Caja 2" />
+        </div>
       </div>
     </>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: dark;
+  color: #f5f5f5;
+  background-color: #333333;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -26,6 +26,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #333333;
+  color: #f5f5f5;
 }
 
 #root {
@@ -56,15 +58,17 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.text-boxes {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.text-boxes input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #666666;
+  border-radius: 4px;
+  background-color: #444444;
+  color: #ffffff;
 }


### PR DESCRIPTION
## Summary
- use a dark gray palette for the frontend
- add two text inputs to the main view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ae17094810833284d0f45fdd20bab6