### PR TITLE
Add responsive navigation to top bar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
-import TopBar from './components/TopBar'
+import TopBar, { Tab } from './components/TopBar'
 
 function App() {
   const [msg, setMsg] = useState('cargando...')
+  const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
 
   useEffect(() => {
     fetch('/api/hello')
@@ -13,16 +14,23 @@ function App() {
 
   return (
     <>
-      <TopBar />
+      <TopBar activeTab={activeTab} onTabChange={setActiveTab} />
       <div style={{ fontFamily: 'system-ui, sans-serif', padding: 24 }}>
         <h1>MP3 Tool</h1>
         <p>
           Backend dice: <strong>{msg}</strong>
         </p>
-        <div className="text-boxes">
-          <input type="text" placeholder="Caja 1" />
-          <input type="text" placeholder="Caja 2" />
-        </div>
+        {activeTab === 'BEATPORT' && (
+          <div className="text-boxes">
+            <input type="text" placeholder="Caja 1" />
+            <input type="text" placeholder="Caja 2" />
+          </div>
+        )}
+        {activeTab === '1001TRACKLIST' && (
+          <label>Pantalla 1001TRACKLIST</label>
+        )}
+        {activeTab === 'BAN/UNBAN' && <label>Pantalla BAN/UNBAN</label>}
+        {activeTab === 'OTROS' && <label>Pantalla OTROS</label>}
       </div>
     </>
   )

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -2,11 +2,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 48px;
-  padding: 0 16px;
+  padding: 8px 16px;
   background-color: #1f1f1f;
   color: #ffffff;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .topbar__logo {
@@ -18,6 +18,28 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
+}
+
+.topbar__nav {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.topbar__tab {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 8px 12px;
+  font-size: 0.9rem;
+}
+
+.topbar__tab--active {
+  border-bottom: 2px solid #646cff;
+  font-weight: bold;
 }
 
 .topbar__settings {

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,17 +1,38 @@
 import { ReactNode } from 'react'
 import './TopBar.css'
 
+export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
+
 interface TopBarProps {
   logo?: ReactNode
+  activeTab: Tab
+  onTabChange: (tab: Tab) => void
 }
 
-const TopBar = ({ logo }: TopBarProps) => {
+const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
+
+const TopBar = ({ logo, activeTab, onTabChange }: TopBarProps) => {
   return (
     <header className="topbar">
       <div className="topbar__logo">{logo}</div>
+      <nav className="topbar__nav">
+        {tabs.map(tab => (
+          <button
+            key={tab}
+            className={`topbar__tab${activeTab === tab ? ' topbar__tab--active' : ''}`}
+            onClick={() => onTabChange(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </nav>
       <button className="topbar__settings" aria-label="Abrir configuración">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path fillRule="evenodd" d="M11.983 2.083a1 1 0 0 1 1.935 0l.342 1.094a1 1 0 0 0 .95.694h1.154a1 1 0 0 1 .986 1.164l-.223 1.274a1 1 0 0 0 .271.907l.817.817a1 1 0 0 1 0 1.414l-.817.817a1 1 0 0 0-.271.907l.223 1.274a1 1 0 0 1-.986 1.164h-1.154a1 1 0 0 0-.95.694l-.342 1.094a1 1 0 0 1-1.935 0l-.342-1.094a1 1 0 0 0-.95-.694H9.537a1 1 0 0 1-.986-1.164l.223-1.274a1 1 0 0 0-.271-.907l-.817-.817a1 1 0 0 1 0-1.414l.817-.817a1 1 0 0 0 .271-.907L8.55 5.035A1 1 0 0 1 9.537 3.87h1.154a1 1 0 0 0 .95-.694l.342-1.094zM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M11.983 2.083a1 1 0 0 1 1.935 0l.342 1.094a1 1 0 0 0 .95.694h1.154a1 1 0 0 1 .986 1.164l-.223 1.274a1 1 0 0 0 .271.907l.817.817a1 1 0 0 1 0 1.414l-.817.817a1 1 0 0 0-.271.907l.223 1.274a1 1 0 0 1-.986 1.164h-1.154a1 1 0 0 0-.95.694l-.342 1.094a1 1 0 0 1-1.935 0l-.342-1.094a1 1 0 0 0-.95-.694H9.537a1 1 0 0 1-.986-1.164l.223-1.274a1 1 0 0 0-.271-.907l-.817-.817a1 1 0 0 1 0-1.414l.817-.817a1 1 0 0 0 .271-.907L8.55 5.035A1 1 0 0 1 9.537 3.87h1.154a1 1 0 0 0 .95-.694l.342-1.094zM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+            clipRule="evenodd"
+          />
         </svg>
       </button>
     </header>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,6 +62,7 @@ button:focus-visible {
   display: flex;
   gap: 8px;
   margin-top: 16px;
+  flex-wrap: wrap;
 }
 
 .text-boxes input {
@@ -71,4 +72,10 @@ button:focus-visible {
   border-radius: 4px;
   background-color: #444444;
   color: #ffffff;
+}
+
+@media (max-width: 600px) {
+  .text-boxes {
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
## Summary
- add Beatport, 1001Tracklist, Ban/Unban and Otros screens
- move text inputs into Beatport and add placeholder labels elsewhere
- make top bar and text boxes responsive

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ae1b29f3ac8332aef4269432471522