### PR TITLE
feat: settings modal with changelog

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "changelog": "node scripts/generate-changelog.js"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/frontend/public/changelog.json
+++ b/frontend/public/changelog.json
@@ -1,0 +1,92 @@
+[
+  {
+    "hash": "750483a",
+    "date": "2025-08-26",
+    "message": "fix! errores"
+  },
+  {
+    "hash": "c71cee6",
+    "date": "2025-08-26",
+    "message": "feat! add texts and functionality to topbar"
+  },
+  {
+    "hash": "b84e450",
+    "date": "2025-08-26",
+    "message": "feat: add responsive navigation screens"
+  },
+  {
+    "hash": "f841b0b",
+    "date": "2025-08-26",
+    "message": "fix! modify frontend design to dark gray"
+  },
+  {
+    "hash": "46b6261",
+    "date": "2025-08-26",
+    "message": "feat: dark theme with input boxes"
+  },
+  {
+    "hash": "b133f59",
+    "date": "2025-08-26",
+    "message": "fix topbar positioning and menu removal"
+  },
+  {
+    "hash": "bbb6c79",
+    "date": "2025-08-26",
+    "message": "fix: ensure top bar spans full width and hide default menu"
+  },
+  {
+    "hash": "1c9d0a6",
+    "date": "2025-08-26",
+    "message": "fix! apertura del programa"
+  },
+  {
+    "hash": "85777ae",
+    "date": "2025-08-26",
+    "message": "debug! createwindow not called"
+  },
+  {
+    "hash": "dffd9a8",
+    "date": "2025-08-26",
+    "message": "fix: ensure createWindow triggers after Vite ready"
+  },
+  {
+    "hash": "f79a7cd",
+    "date": "2025-08-26",
+    "message": "fix spawn einval error in startvite"
+  },
+  {
+    "hash": "338d0f5",
+    "date": "2025-08-26",
+    "message": "fix: run vite via shell to avoid spawn error"
+  },
+  {
+    "hash": "641012e",
+    "date": "2025-08-26",
+    "message": "fix! blank app menu issue"
+  },
+  {
+    "hash": "f197119",
+    "date": "2025-08-26",
+    "message": "Start Vite server alongside Electron app"
+  },
+  {
+    "hash": "345b8ce",
+    "date": "2025-08-26",
+    "message": "feat! add topbar and side logo layout"
+  },
+  {
+    "hash": "58ebfa3",
+    "date": "2025-08-26",
+    "message": "refactor: allow custom logo in top bar"
+  },
+  {
+    "hash": "4e6be64",
+    "date": "2025-08-26",
+    "message": "new! subida del proyecto inicial"
+  },
+  {
+    "hash": "c993f0d",
+    "date": "2025-08-26",
+    "message": "Initial commit"
+  }
+]

--- a/frontend/scripts/generate-changelog.js
+++ b/frontend/scripts/generate-changelog.js
@@ -1,0 +1,25 @@
+import { execSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, '..')
+
+const log = execSync('git log --pretty=format:%h%x09%ad%x09%s --date=short', {
+  cwd: root,
+  encoding: 'utf-8'
+})
+
+const entries = log
+  .trim()
+  .split('\n')
+  .map(line => {
+    const [hash, date, ...messageParts] = line.split('\t')
+    const message = messageParts.join('\t')
+    return { hash, date, message }
+  })
+
+const outFile = path.join(root, 'public', 'changelog.json')
+writeFileSync(outFile, JSON.stringify(entries, null, 2))
+console.log(`Generated changelog with ${entries.length} entries`) 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
 import TopBar, { type Tab } from './components/TopBar'
+import SettingsModal from './components/SettingsModal'
 
 function App() {
   const [msg, setMsg] = useState('cargando...')
   const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   useEffect(() => {
     fetch('/api/hello')
@@ -14,7 +16,11 @@ function App() {
 
   return (
     <>
-      <TopBar activeTab={activeTab} onTabChange={setActiveTab} />
+      <TopBar
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        onSettingsClick={() => setSettingsOpen(true)}
+      />
       <div style={{ fontFamily: 'system-ui, sans-serif', padding: 24 }}>
         <h1>MP3 Tool</h1>
         <p>
@@ -32,6 +38,7 @@ function App() {
         {activeTab === 'BAN/UNBAN' && <label>Pantalla BAN/UNBAN</label>}
         {activeTab === 'OTROS' && <label>Pantalla OTROS</label>}
       </div>
+      {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
     </>
   )
 }

--- a/frontend/src/components/SettingsModal.css
+++ b/frontend/src/components/SettingsModal.css
@@ -1,0 +1,81 @@
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-modal {
+  background: #1f1f1f;
+  color: #fff;
+  width: 600px;
+  max-width: 90%;
+  border-radius: 8px;
+  padding: 24px;
+}
+
+.settings-header {
+  position: relative;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.settings-close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.settings-tabs {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.settings-tabs button {
+  flex: 1;
+  background: none;
+  border: none;
+  color: #888;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.settings-tabs button.active {
+  color: #fff;
+  border-bottom: 2px solid #646cff;
+}
+
+.settings-content {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.changelog-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.changelog-list li {
+  margin-bottom: 8px;
+}
+
+.changelog-date {
+  color: #888;
+  margin-right: 8px;
+  font-size: 0.8rem;
+}
+
+.placeholder {
+  color: #888;
+  text-align: center;
+}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+import './SettingsModal.css'
+
+interface ChangelogEntry {
+  hash: string
+  date: string
+  message: string
+}
+
+interface SettingsModalProps {
+  onClose: () => void
+}
+
+type Tab = 'CHANGELOG' | 'QUICK TAG CUSTOM' | 'GENERAL'
+
+const SettingsModal = ({ onClose }: SettingsModalProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>('CHANGELOG')
+  const [entries, setEntries] = useState<ChangelogEntry[]>([])
+
+  useEffect(() => {
+    fetch('/changelog.json')
+      .then(r => r.json())
+      .then(setEntries)
+      .catch(() => setEntries([]))
+  }, [])
+
+  return (
+    <div className="settings-overlay">
+      <div className="settings-modal">
+        <div className="settings-header">
+          <h2>SETTINGS</h2>
+          <button className="settings-close" onClick={onClose} aria-label="Cerrar">
+            &times;
+          </button>
+        </div>
+        <div className="settings-tabs">
+          {(['CHANGELOG', 'QUICK TAG CUSTOM', 'GENERAL'] as Tab[]).map(tab => (
+            <button
+              key={tab}
+              className={tab === activeTab ? 'active' : ''}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="settings-content">
+          {activeTab === 'CHANGELOG' ? (
+            <ul className="changelog-list">
+              {entries.map(e => (
+                <li key={e.hash}>
+                  <span className="changelog-date">{e.date}</span>
+                  <span className="changelog-message">{e.message}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="placeholder">Coming soon...</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SettingsModal

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -7,11 +7,12 @@ interface TopBarProps {
   logo?: ReactNode
   activeTab: Tab
   onTabChange: (tab: Tab) => void
+  onSettingsClick: () => void
 }
 
 const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
 
-const TopBar = ({ logo, activeTab, onTabChange }: TopBarProps) => {
+const TopBar = ({ logo, activeTab, onTabChange, onSettingsClick }: TopBarProps) => {
   return (
     <header className="topbar">
       <div className="topbar__logo">{logo}</div>
@@ -26,7 +27,7 @@ const TopBar = ({ logo, activeTab, onTabChange }: TopBarProps) => {
           </button>
         ))}
       </nav>
-      <button className="topbar__settings" aria-label="Abrir configuración">
+      <button className="topbar__settings" aria-label="Abrir configuración" onClick={onSettingsClick}>
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path
             fillRule="evenodd"


### PR DESCRIPTION
## Summary
- add settings modal with tabs and changelog screen
- show commit history from generated changelog.json
- script to auto-generate changelog from git history

## Testing
- `npm run lint`
- `npm run changelog`


------
https://chatgpt.com/codex/tasks/task_b_68aec7ab111c833280e1763d99946610