### PR TITLE
fix(topbar): remove focus outline and hide scrollbars

### DIFF
--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -37,6 +37,11 @@
   font-size: 0.9rem;
 }
 
+.topbar__tab:focus,
+.topbar__tab:focus-visible {
+  outline: none;
+}
+
 .topbar__tab--active {
   border-bottom: 2px solid #646cff;
   font-weight: bold;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,6 +28,7 @@ body {
   min-height: 100vh;
   background-color: #333333;
   color: #f5f5f5;
+  overflow: hidden;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- prevent topbar tabs from keeping white focus border
- hide page scrollbars to fully show topbar settings icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af1ad794988332a0712937b17bfcea