### PR TITLE
fix: prevent settings icon from clipping in top bar

### DIFF
--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -6,6 +6,7 @@
   background-color: #1f1f1f;
   color: #ffffff;
   width: 100%;
+  box-sizing: border-box;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary
- ensure TopBar padding doesn't clip the settings icon by using border-box sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af1bf456308332aff16099ad949cf5