### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ function App() {
   const [msg, setMsg] = useState('cargando...')
   const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
 
   useEffect(() => {
     fetch('/api/hello')
@@ -13,6 +14,20 @@ function App() {
       .then(d => setMsg(d.message))
       .catch(() => setMsg('Error conectando con el backend'))
   }, [])
+
+  useEffect(() => {
+    const stored = (localStorage.getItem('theme') as 'light' | 'dark' | null)
+    if (stored) {
+      setTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    localStorage.setItem('theme', theme)
+  }, [theme])
 
   return (
     <>
@@ -38,7 +53,13 @@ function App() {
         {activeTab === 'BAN/UNBAN' && <label>Pantalla BAN/UNBAN</label>}
         {activeTab === 'OTROS' && <label>Pantalla OTROS</label>}
       </div>
-      {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
+      {settingsOpen && (
+        <SettingsModal
+          onClose={() => setSettingsOpen(false)}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/components/SettingsModal.css
+++ b/frontend/src/components/SettingsModal.css
@@ -9,8 +9,8 @@
 }
 
 .settings-modal {
-  background: #1f1f1f;
-  color: #fff;
+  background: var(--surface-color);
+  color: var(--text-color);
   width: 600px;
   max-width: 90%;
   border-radius: 8px;
@@ -29,7 +29,7 @@
   top: 0;
   background: none;
   border: none;
-  color: #fff;
+  color: var(--text-color);
   font-size: 24px;
   cursor: pointer;
 }
@@ -44,14 +44,14 @@
   flex: 1;
   background: none;
   border: none;
-  color: #888;
+  color: var(--muted-color);
   padding: 8px 12px;
   cursor: pointer;
 }
 
 .settings-tabs button.active {
-  color: #fff;
-  border-bottom: 2px solid #646cff;
+  color: var(--text-color);
+  border-bottom: 2px solid var(--accent-color);
 }
 
 .settings-content {
@@ -70,12 +70,22 @@
 }
 
 .changelog-date {
-  color: #888;
+  color: var(--muted-color);
   margin-right: 8px;
   font-size: 0.8rem;
 }
 
 .placeholder {
-  color: #888;
+  color: var(--muted-color);
   text-align: center;
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-toggle input[type='checkbox'] {
+  accent-color: var(--accent-color);
 }

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -9,11 +9,13 @@ interface ChangelogEntry {
 
 interface SettingsModalProps {
   onClose: () => void
+  theme: 'light' | 'dark'
+  onThemeChange: (theme: 'light' | 'dark') => void
 }
 
 type Tab = 'CHANGELOG' | 'QUICK TAG CUSTOM' | 'GENERAL'
 
-const SettingsModal = ({ onClose }: SettingsModalProps) => {
+const SettingsModal = ({ onClose, theme, onThemeChange }: SettingsModalProps) => {
   const [activeTab, setActiveTab] = useState<Tab>('CHANGELOG')
   const [entries, setEntries] = useState<ChangelogEntry[]>([])
 
@@ -45,7 +47,7 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
           ))}
         </div>
         <div className="settings-content">
-          {activeTab === 'CHANGELOG' ? (
+          {activeTab === 'CHANGELOG' && (
             <ul className="changelog-list">
               {entries.map(e => (
                 <li key={e.hash}>
@@ -54,8 +56,19 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
                 </li>
               ))}
             </ul>
-          ) : (
-            <div className="placeholder">Coming soon...</div>
+          )}
+          {activeTab === 'QUICK TAG CUSTOM' && <div className="placeholder">Coming soon...</div>}
+          {activeTab === 'GENERAL' && (
+            <div className="theme-toggle">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={theme === 'dark'}
+                  onChange={e => onThemeChange(e.target.checked ? 'dark' : 'light')}
+                />
+                Dark mode
+              </label>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -3,8 +3,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px 16px;
-  background-color: #1f1f1f;
-  color: #ffffff;
+  background-color: var(--surface-color);
+  color: var(--text-color);
   width: 100%;
   box-sizing: border-box;
   flex-wrap: wrap;
@@ -14,7 +14,7 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background-color: #333333;
+  background-color: var(--bg-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -44,7 +44,7 @@
 }
 
 .topbar__tab--active {
-  border-bottom: 2px solid #646cff;
+  border-bottom: 2px solid var(--accent-color);
   font-weight: bold;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,23 @@
+/*
+  Global theme variables. The default theme is light and a "dark" theme can be
+  activated by setting `data-theme="dark"` on the document element.
+*/
 :root {
+  /* Typography */
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: dark;
-  color: #f5f5f5;
-  background-color: #333333;
+  /* Light theme colors */
+  --bg-color: #f5f5f5;
+  --text-color: #1f1f1f;
+  --surface-color: #ffffff;
+  --accent-color: #646cff;
+  --muted-color: #888888;
+
+  color-scheme: light;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,21 +25,33 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+[data-theme='dark'] {
+  --bg-color: #333333;
+  --text-color: #f5f5f5;
+  --surface-color: #1f1f1f;
+  --accent-color: #646cff;
+  --muted-color: #bbbbbb;
+
+  color-scheme: dark;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  opacity: 0.85;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: #333333;
-  color: #f5f5f5;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   overflow: hidden;
 }
 
@@ -47,12 +71,13 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--surface-color);
+  color: var(--text-color);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 button:focus,
 button:focus-visible {
@@ -69,10 +94,10 @@ button:focus-visible {
 .text-boxes input {
   flex: 1;
   padding: 8px;
-  border: 1px solid #666666;
+  border: 1px solid var(--muted-color);
   border-radius: 4px;
-  background-color: #444444;
-  color: #ffffff;
+  background-color: var(--surface-color);
+  color: var(--text-color);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- introduce global CSS variables and theme definitions
- allow switching between light and dark mode in the settings modal
- persist theme preference and update UI components to respect the theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af5b7f5b148332968c3a284c897bb3