### PR TITLE
feat: update color palette for light and dark themes

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,11 +9,11 @@
   font-weight: 400;
 
   /* Light theme colors */
-  --bg-color: #f5f5f5;
-  --text-color: #1f1f1f;
+  --bg-color: #f0f4f8;
+  --text-color: #1e293b;
   --surface-color: #ffffff;
-  --accent-color: #646cff;
-  --muted-color: #888888;
+  --accent-color: #3b82f6;
+  --muted-color: #94a3b8;
 
   color-scheme: light;
   color: var(--text-color);
@@ -26,11 +26,11 @@
 }
 
 [data-theme='dark'] {
-  --bg-color: #333333;
-  --text-color: #f5f5f5;
-  --surface-color: #1f1f1f;
-  --accent-color: #646cff;
-  --muted-color: #bbbbbb;
+  --bg-color: #0f172a;
+  --text-color: #e2e8f0;
+  --surface-color: #1e293b;
+  --accent-color: #60a5fa;
+  --muted-color: #64748b;
 
   color-scheme: dark;
   background-color: var(--bg-color);


### PR DESCRIPTION
## Summary
- refresh global CSS variables with a harmonious color palette for light and dark modes

## Testing
- `npm test` *(fails: Missing script "test" and provides notice)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af6eb8c3c083329f4f64f703aa21ef