### PR TITLE
feat: add icons to top bar tabs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -2887,6 +2888,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -36,6 +36,9 @@
   cursor: pointer;
   padding: 8px 12px;
   font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .topbar__tab:focus,

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 import './TopBar.css'
+import { FaMusic, FaList, FaBan, FaEllipsisH } from 'react-icons/fa'
+import type { IconType } from 'react-icons'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
 
@@ -12,20 +14,31 @@ interface TopBarProps {
 
 const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
 
+const tabIcons: Record<Tab, IconType> = {
+  BEATPORT: FaMusic,
+  '1001TRACKLIST': FaList,
+  'BAN/UNBAN': FaBan,
+  OTROS: FaEllipsisH,
+}
+
 const TopBar = ({ logo, activeTab, onTabChange, onSettingsClick }: TopBarProps) => {
   return (
     <header className="topbar">
       <div className="topbar__logo">{logo}</div>
       <nav className="topbar__nav">
-        {tabs.map(tab => (
-          <button
-            key={tab}
-            className={`topbar__tab${activeTab === tab ? ' topbar__tab--active' : ''}`}
-            onClick={() => onTabChange(tab)}
-          >
-            {tab}
-          </button>
-        ))}
+        {tabs.map(tab => {
+          const Icon = tabIcons[tab]
+          return (
+            <button
+              key={tab}
+              className={`topbar__tab${activeTab === tab ? ' topbar__tab--active' : ''}`}
+              onClick={() => onTabChange(tab)}
+            >
+              <Icon />
+              {tab}
+            </button>
+          )
+        })}
       </nav>
       <button className="topbar__settings" aria-label="Abrir configuración" onClick={onSettingsClick}>
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## Summary
- install react-icons
- show icons for each top bar tab with spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af6f6aef848332957d11986b6a9aca