### PR TITLE
feat: animate settings modal

### DIFF
--- a/frontend/src/components/SettingsModal.css
+++ b/frontend/src/components/SettingsModal.css
@@ -1,3 +1,23 @@
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modalFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .settings-overlay {
   position: fixed;
   inset: 0;
@@ -6,6 +26,13 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  opacity: 0;
+  animation: overlayFadeIn 0.2s forwards;
+  transition: opacity 0.2s ease;
+}
+
+.settings-overlay.closing {
+  opacity: 0;
 }
 
 .settings-modal {
@@ -15,6 +42,15 @@
   max-width: 90%;
   border-radius: 8px;
   padding: 24px;
+  opacity: 0;
+  transform: scale(0.95);
+  animation: modalFadeIn 0.2s forwards;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.settings-modal.closing {
+  opacity: 0;
+  transform: scale(0.95);
 }
 
 .settings-header {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ type Tab = 'CHANGELOG' | 'QUICK TAG CUSTOM' | 'GENERAL'
 const SettingsModal = ({ onClose, theme, onThemeChange }: SettingsModalProps) => {
   const [activeTab, setActiveTab] = useState<Tab>('CHANGELOG')
   const [entries, setEntries] = useState<ChangelogEntry[]>([])
+  const [isClosing, setIsClosing] = useState(false)
 
   useEffect(() => {
     fetch('/changelog.json')
@@ -26,12 +27,17 @@ const SettingsModal = ({ onClose, theme, onThemeChange }: SettingsModalProps) =>
       .catch(() => setEntries([]))
   }, [])
 
+  const handleClose = () => {
+    setIsClosing(true)
+    setTimeout(onClose, 200)
+  }
+
   return (
-    <div className="settings-overlay">
-      <div className="settings-modal">
+    <div className={`settings-overlay${isClosing ? ' closing' : ''}`}>
+      <div className={`settings-modal${isClosing ? ' closing' : ''}`}>
         <div className="settings-header">
           <h2>SETTINGS</h2>
-          <button className="settings-close" onClick={onClose} aria-label="Cerrar">
+          <button className="settings-close" onClick={handleClose} aria-label="Cerrar">
             &times;
           </button>
         </div>


### PR DESCRIPTION
## Summary
- add fade/scale animations to settings modal overlay
- delay unmounting so closing animation can finish

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af716fe37883329ec5fec2b423c3d1