### PR TITLE
feat: responsive top bar menu

### DIFF
--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -64,3 +64,39 @@
   width: 24px;
   height: 24px;
 }
+
+.topbar__menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.topbar__menu-toggle svg {
+  width: 24px;
+  height: 24px;
+}
+
+@media (max-width: 768px) {
+  .topbar__menu-toggle {
+    display: block;
+  }
+
+  .topbar__nav {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .topbar__nav--open {
+    display: flex;
+  }
+
+  .topbar__settings {
+    margin-left: auto;
+  }
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
+import { useState, type ReactNode, type KeyboardEvent } from 'react'
 import './TopBar.css'
-import { FaMusic, FaList, FaBan, FaEllipsisH } from 'react-icons/fa'
+import { FaMusic, FaList, FaBan, FaEllipsisH, FaBars } from 'react-icons/fa'
 import type { IconType } from 'react-icons'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -22,17 +22,43 @@ const tabIcons: Record<Tab, IconType> = {
 }
 
 const TopBar = ({ logo, activeTab, onTabChange, onSettingsClick }: TopBarProps) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const toggleMenu = () => setIsMenuOpen(prev => !prev)
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsMenuOpen(false)
+    }
+  }
+
   return (
     <header className="topbar">
       <div className="topbar__logo">{logo}</div>
-      <nav className="topbar__nav">
+      <button
+        className="topbar__menu-toggle"
+        aria-label={isMenuOpen ? 'Cerrar menú' : 'Abrir menú'}
+        aria-expanded={isMenuOpen}
+        aria-controls="topbar-menu"
+        onClick={toggleMenu}
+      >
+        <FaBars />
+      </button>
+      <nav
+        id="topbar-menu"
+        className={`topbar__nav${isMenuOpen ? ' topbar__nav--open' : ''}`}
+        onKeyDown={handleKeyDown}
+      >
         {tabs.map(tab => {
           const Icon = tabIcons[tab]
           return (
             <button
               key={tab}
               className={`topbar__tab${activeTab === tab ? ' topbar__tab--active' : ''}`}
-              onClick={() => onTabChange(tab)}
+              onClick={() => {
+                onTabChange(tab)
+                setIsMenuOpen(false)
+              }}
             >
               <Icon />
               {tab}


### PR DESCRIPTION
## Summary
- add hamburger button and stateful mobile menu in TopBar
- hide navigation on small screens and show dropdown via media queries
- ensure navigation menu is keyboard and screen-reader accessible

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af729f58a083329cc13517f1efe414