### PR TITLE
feat: centralize theme handling with context provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ function App() {
   const [msg, setMsg] = useState('cargando...')
   const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const [theme, setTheme] = useState<'light' | 'dark'>('light')
 
   useEffect(() => {
     fetch('/api/hello')
@@ -15,19 +14,6 @@ function App() {
       .catch(() => setMsg('Error conectando con el backend'))
   }, [])
 
-  useEffect(() => {
-    const stored = (localStorage.getItem('theme') as 'light' | 'dark' | null)
-    if (stored) {
-      setTheme(stored)
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setTheme('dark')
-    }
-  }, [])
-
-  useEffect(() => {
-    document.documentElement.dataset.theme = theme
-    localStorage.setItem('theme', theme)
-  }, [theme])
 
   return (
     <>
@@ -56,8 +42,6 @@ function App() {
       {settingsOpen && (
         <SettingsModal
           onClose={() => setSettingsOpen(false)}
-          theme={theme}
-          onThemeChange={setTheme}
         />
       )}
     </>

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import './SettingsModal.css'
+import { useTheme } from '../theme/ThemeContext'
 
 interface ChangelogEntry {
   hash: string
@@ -9,16 +10,15 @@ interface ChangelogEntry {
 
 interface SettingsModalProps {
   onClose: () => void
-  theme: 'light' | 'dark'
-  onThemeChange: (theme: 'light' | 'dark') => void
 }
 
 type Tab = 'CHANGELOG' | 'QUICK TAG CUSTOM' | 'GENERAL'
 
-const SettingsModal = ({ onClose, theme, onThemeChange }: SettingsModalProps) => {
+const SettingsModal = ({ onClose }: SettingsModalProps) => {
   const [activeTab, setActiveTab] = useState<Tab>('CHANGELOG')
   const [entries, setEntries] = useState<ChangelogEntry[]>([])
   const [isClosing, setIsClosing] = useState(false)
+  const { theme, setTheme } = useTheme()
 
   useEffect(() => {
     fetch('/changelog.json')
@@ -70,7 +70,7 @@ const SettingsModal = ({ onClose, theme, onThemeChange }: SettingsModalProps) =>
                 <input
                   type="checkbox"
                   checked={theme === 'dark'}
-                  onChange={e => onThemeChange(e.target.checked ? 'dark' : 'light')}
+                  onChange={e => setTheme(e.target.checked ? 'dark' : 'light')}
                 />
                 Dark mode
               </label>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './theme/ThemeContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/frontend/src/theme/ThemeContext.tsx
+++ b/frontend/src/theme/ThemeContext.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored) {
+      setTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}
+
+export default ThemeContext


### PR DESCRIPTION
## Summary
- add ThemeContext with provider managing theme persistence and document dataset
- wrap App with ThemeProvider to supply theme state
- consume ThemeContext in SettingsModal and remove prop drilling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68afed62195483329d9eee1eb073f177