### PR TITLE
refactor: separar vistas en tabs con lazy loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, lazy, Suspense } from 'react'
 import TopBar, { type Tab } from './components/TopBar'
 import SettingsModal from './components/SettingsModal'
+
+const BeatportTab = lazy(() => import('./tabs/Beatport/BeatportTab'))
+const TracklistTab = lazy(() => import('./tabs/Tracklist/TracklistTab'))
+const BanTab = lazy(() => import('./tabs/Ban/BanTab'))
+const OtrosTab = lazy(() => import('./tabs/Otros/OtrosTab'))
 
 function App() {
   const [msg, setMsg] = useState('cargando...')
@@ -27,17 +32,12 @@ function App() {
         <p>
           Backend dice: <strong>{msg}</strong>
         </p>
-        {activeTab === 'BEATPORT' && (
-          <div className="text-boxes">
-            <input type="text" placeholder="Caja 1" />
-            <input type="text" placeholder="Caja 2" />
-          </div>
-        )}
-        {activeTab === '1001TRACKLIST' && (
-          <label>Pantalla 1001TRACKLIST</label>
-        )}
-        {activeTab === 'BAN/UNBAN' && <label>Pantalla BAN/UNBAN</label>}
-        {activeTab === 'OTROS' && <label>Pantalla OTROS</label>}
+        <Suspense fallback={<div>Cargando...</div>}>
+          {activeTab === 'BEATPORT' && <BeatportTab />}
+          {activeTab === '1001TRACKLIST' && <TracklistTab />}
+          {activeTab === 'BAN/UNBAN' && <BanTab />}
+          {activeTab === 'OTROS' && <OtrosTab />}
+        </Suspense>
       </div>
       {settingsOpen && (
         <SettingsModal

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -1,0 +1,5 @@
+const BanTab = () => {
+  return <label>Pantalla BAN/UNBAN</label>
+}
+
+export default BanTab

--- a/frontend/src/tabs/Beatport/BeatportTab.tsx
+++ b/frontend/src/tabs/Beatport/BeatportTab.tsx
@@ -1,0 +1,10 @@
+const BeatportTab = () => {
+  return (
+    <div className="text-boxes">
+      <input type="text" placeholder="Caja 1" />
+      <input type="text" placeholder="Caja 2" />
+    </div>
+  )
+}
+
+export default BeatportTab

--- a/frontend/src/tabs/Otros/OtrosTab.tsx
+++ b/frontend/src/tabs/Otros/OtrosTab.tsx
@@ -1,0 +1,5 @@
+const OtrosTab = () => {
+  return <label>Pantalla OTROS</label>
+}
+
+export default OtrosTab

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -1,0 +1,5 @@
+const TracklistTab = () => {
+  return <label>Pantalla 1001TRACKLIST</label>
+}
+
+export default TracklistTab


### PR DESCRIPTION
## Summary
- mover el contenido de cada pestaña a componentes dedicados
- cargar cada vista de forma perezosa con `React.lazy`

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afee7eac5883328b1e7ce146ac8755