### PR TITLE
feat: configure API base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ celerybeat.pid
 
 # Environments
 .env
+!frontend/.env
+!frontend/.env.production
 .envrc
 .venv
 env/

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,3 +67,18 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Configurar el endpoint del backend
+
+Define la variable `VITE_API_BASE` para apuntar al backend en distintos entornos:
+
+```bash
+# .env (desarrollo)
+VITE_API_BASE=/api
+
+# .env.production (producción)
+VITE_API_BASE=https://api.ejemplo.com/api
+```
+
+Vite expone esta variable como `import.meta.env.VITE_API_BASE`. El archivo `frontend/src/config.ts` la lee para construir las URLs del backend.
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, lazy, Suspense } from 'react'
+import { API_BASE } from './config'
 import TopBar, { type Tab } from './components/TopBar'
 import SettingsModal from './components/SettingsModal'
 
@@ -13,7 +14,7 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
 
   useEffect(() => {
-    fetch('/api/hello')
+    fetch(`${API_BASE}/hello`)
       .then(r => r.json())
       .then(d => setMsg(d.message))
       .catch(() => setMsg('Error conectando con el backend'))

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE = import.meta.env.VITE_API_BASE as string
+


### PR DESCRIPTION
## Summary
- add config file reading `VITE_API_BASE`
- use API base when calling backend
- document environment configuration for different backends

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b02ea754048332b0c6cba207c8c45a