### PR TITLE
fix: avoid returning element from ref callback

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -68,7 +68,9 @@ const TopBar = ({ logo, activeTab, onTabChange, onSettingsClick }: TopBarProps) 
           return (
             <button
               key={tab}
-              ref={el => (tabRefs.current[index] = el)}
+              ref={el => {
+                tabRefs.current[index] = el
+              }}
               className={`topbar__tab${activeTab === tab ? ' topbar__tab--active' : ''}`}
               onClick={() => {
                 onTabChange(tab)


### PR DESCRIPTION
## Summary
- use a block body in TopBar's tab ref callback to avoid returning the element

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b03f3d84248332a80ffd1ed98a12d7