### PR TITLE
feat: add demo tracklist viewer

### DIFF
--- a/frontend/src/tabs/Tracklist/TracklistTab.css
+++ b/frontend/src/tabs/Tracklist/TracklistTab.css
@@ -1,0 +1,57 @@
+.tracklist-container {
+  display: flex;
+  gap: 12px;
+}
+
+.tracklists-panel {
+  width: 20%;
+  border-right: 1px solid #444;
+}
+
+.tracklists-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tracklists-panel li {
+  padding: 8px;
+  cursor: pointer;
+}
+
+.tracklists-panel li.active {
+  background-color: #333;
+  color: #fff;
+}
+
+.tracks-panel {
+  flex: 1;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 0.5s forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+.loading {
+  padding: 20px;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.3; }
+  50% { opacity: 1; }
+  100% { opacity: 0.3; }
+}
+
+.filter-panel {
+  width: 20%;
+  border-left: 1px solid #444;
+  padding-left: 8px;
+}

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -1,5 +1,101 @@
+import { useState, useEffect } from 'react'
+import './TracklistTab.css'
+import { tracklists, type Track } from './sampleData'
+import { FaStar, FaRegStar } from 'react-icons/fa'
+
 const TracklistTab = () => {
-  return <label>Pantalla 1001TRACKLIST</label>
+  const [selectedId, setSelectedId] = useState(tracklists[0]?.id)
+  const [tracks, setTracks] = useState<Track[]>(tracklists[0]?.tracks ?? [])
+  const [loading, setLoading] = useState(false)
+  const [minEnergy, setMinEnergy] = useState(0)
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id)
+  }
+
+  useEffect(() => {
+    const tl = tracklists.find(t => t.id === selectedId)
+    if (!tl) return
+    setLoading(true)
+    const timer = setTimeout(() => {
+      setTracks(tl.tracks)
+      setLoading(false)
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [selectedId])
+
+  const filteredTracks = tracks.filter(t => t.energy >= minEnergy)
+
+  const renderStars = (count: number) => {
+    return Array.from({ length: 5 }, (_, i) =>
+      i < count ? <FaStar key={i} color="#ffc107" /> : <FaRegStar key={i} color="#555" />
+    )
+  }
+
+  return (
+    <div className="tracklist-container">
+      <aside className="tracklists-panel">
+        <ul>
+          {tracklists.map(tl => (
+            <li
+              key={tl.id}
+              className={tl.id === selectedId ? 'active' : ''}
+              onClick={() => handleSelect(tl.id)}
+            >
+              {tl.name}
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="tracks-panel">
+        {loading ? (
+          <div className="loading">Cargando...</div>
+        ) : (
+          <table className="fade-in">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Tema</th>
+                <th>Custom</th>
+                <th>Mood</th>
+                <th>Energy</th>
+                <th>Género</th>
+                <th>Año</th>
+                <th>Tipo</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTracks.map((track, idx) => (
+                <tr key={track.id}>
+                  <td>{idx + 1}</td>
+                  <td>{track.artists} - {track.title}</td>
+                  <td>{track.custom}</td>
+                  <td>{track.mood}</td>
+                  <td>{renderStars(track.energy)}</td>
+                  <td>{track.genre}</td>
+                  <td>{track.year}</td>
+                  <td>{track.type}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+      <aside className="filter-panel">
+        <label>
+          Energía mínima
+          <select value={minEnergy} onChange={e => setMinEnergy(Number(e.target.value))}>
+            <option value={0}>Todas</option>
+            <option value={1}>1+</option>
+            <option value={2}>2+</option>
+            <option value={3}>3+</option>
+            <option value={4}>4+</option>
+            <option value={5}>5</option>
+          </select>
+        </label>
+      </aside>
+    </div>
+  )
 }
 
 export default TracklistTab

--- a/frontend/src/tabs/Tracklist/sampleData.ts
+++ b/frontend/src/tabs/Tracklist/sampleData.ts
@@ -1,0 +1,87 @@
+export interface Track {
+  id: string
+  title: string
+  artists: string
+  custom: string
+  mood: string
+  energy: number
+  genre: string
+  year: number
+  type: string
+}
+
+export interface Tracklist {
+  id: string
+  name: string
+  tracks: Track[]
+}
+
+export const tracklists: Tracklist[] = [
+  {
+    id: 'tl1',
+    name: 'Set de Prueba 1',
+    tracks: [
+      {
+        id: 't1',
+        title: 'Dub Me Back',
+        artists: 'DJ DLG ft. B. Martin',
+        custom: 'Rework',
+        mood: 'mood 1',
+        energy: 5,
+        genre: 'Pumping House',
+        year: 2023,
+        type: 'Original Mix',
+      },
+      {
+        id: 't2',
+        title: 'Fear Factory',
+        artists: 'Cleeny',
+        custom: 'Edit',
+        mood: 'mood 2',
+        energy: 4,
+        genre: 'Techno',
+        year: 2024,
+        type: 'Remix',
+      },
+      {
+        id: 't3',
+        title: 'Find My',
+        artists: 'Wody Beats & Style',
+        custom: 'Mashup',
+        mood: 'mood 3',
+        energy: 3,
+        genre: 'Trance',
+        year: 2023,
+        type: 'Bootleg',
+      },
+    ],
+  },
+  {
+    id: 'tl2',
+    name: 'Set de Prueba 2',
+    tracks: [
+      {
+        id: 't4',
+        title: 'In My Soul',
+        artists: 'Golhard',
+        custom: 'Extended',
+        mood: 'mood 1',
+        energy: 2,
+        genre: 'House',
+        year: 2022,
+        type: 'Original Mix',
+      },
+      {
+        id: 't5',
+        title: 'Everything Club',
+        artists: 'Safe-ID',
+        custom: 'Rework',
+        mood: 'mood 2',
+        energy: 5,
+        genre: 'Trance',
+        year: 2024,
+        type: 'Bootleg',
+      },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- build placeholder tracklist viewer with selectable tracklists
- display tracks with fade-in effect and energy filter
- include sample data and basic styling

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b041b6250083328e1c5f33b19e831d