### PR TITLE
Expand Tracklist rows with media preview

### DIFF
--- a/frontend/src/tabs/Tracklist/TracklistTab.css
+++ b/frontend/src/tabs/Tracklist/TracklistTab.css
@@ -55,6 +55,27 @@
   font-size: 0.7em;
 }
 
+.track-row {
+  cursor: pointer;
+}
+
+.expanded-row td {
+  background-color: #2a2a2a;
+  transition: background-color 0.3s ease;
+}
+
+.expanded-content {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.expanded-content img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+
 .fade-in {
   opacity: 0;
   animation: fadeIn 0.5s forwards;

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 import './TracklistTab.css'
 import { tracklists, type Track } from './sampleData'
 import { FaStar, FaRegStar } from 'react-icons/fa'
@@ -12,6 +12,7 @@ const TracklistTab = () => {
   type SortKey = 'index' | 'theme' | 'custom' | 'mood' | 'energy' | 'genre' | 'year' | 'type'
   const [sortBy, setSortBy] = useState<SortKey>('index')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
+  const [expandedTrack, setExpandedTrack] = useState<string | null>(null)
 
   const handleSelect = (id: string) => {
     setSelectedId(id)
@@ -69,6 +70,10 @@ const TracklistTab = () => {
       setSortBy(column)
       setSortDirection('asc')
     }
+  }
+
+  const toggleExpand = (id: string) => {
+    setExpandedTrack(prev => (prev === id ? null : id))
   }
 
   return (
@@ -152,18 +157,33 @@ const TracklistTab = () => {
             </thead>
             <tbody>
               {sortedTracks.map((track, idx) => (
-                <tr key={track.id}>
-                  <td>{idx + 1}</td>
-                  <td>
-                    {track.artists} - {track.title}
-                  </td>
-                  <td>{track.custom}</td>
-                  <td>{track.mood}</td>
-                  <td>{renderStars(track.energy)}</td>
-                  <td>{track.genre}</td>
-                  <td>{track.year}</td>
-                  <td>{track.type}</td>
-                </tr>
+                <Fragment key={track.id}>
+                  <tr
+                    onClick={() => toggleExpand(track.id)}
+                    className="track-row"
+                  >
+                    <td>{idx + 1}</td>
+                    <td>
+                      {track.artists} - {track.title}
+                    </td>
+                    <td>{track.custom}</td>
+                    <td>{track.mood}</td>
+                    <td>{renderStars(track.energy)}</td>
+                    <td>{track.genre}</td>
+                    <td>{track.year}</td>
+                    <td>{track.type}</td>
+                  </tr>
+                  {expandedTrack === track.id && (
+                    <tr className="expanded-row">
+                      <td colSpan={8}>
+                        <div className="expanded-content">
+                          <img src={track.imageUrl} alt={track.title} />
+                          <audio controls src={track.previewUrl} />
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
             </tbody>
           </table>

--- a/frontend/src/tabs/Tracklist/sampleData.ts
+++ b/frontend/src/tabs/Tracklist/sampleData.ts
@@ -8,6 +8,8 @@ export interface Track {
   genre: string
   year: number
   type: string
+  imageUrl: string
+  previewUrl: string
 }
 
 export interface Tracklist {
@@ -31,6 +33,8 @@ export const tracklists: Tracklist[] = [
         genre: 'Pumping House',
         year: 2023,
         type: 'Original Mix',
+        imageUrl: 'https://picsum.photos/seed/t1/200/200',
+        previewUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
       },
       {
         id: 't2',
@@ -42,6 +46,8 @@ export const tracklists: Tracklist[] = [
         genre: 'Techno',
         year: 2024,
         type: 'Remix',
+        imageUrl: 'https://picsum.photos/seed/t2/200/200',
+        previewUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
       },
       {
         id: 't3',
@@ -53,6 +59,8 @@ export const tracklists: Tracklist[] = [
         genre: 'Trance',
         year: 2023,
         type: 'Bootleg',
+        imageUrl: 'https://picsum.photos/seed/t3/200/200',
+        previewUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3',
       },
     ],
   },
@@ -70,6 +78,8 @@ export const tracklists: Tracklist[] = [
         genre: 'House',
         year: 2022,
         type: 'Original Mix',
+        imageUrl: 'https://picsum.photos/seed/t4/200/200',
+        previewUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3',
       },
       {
         id: 't5',
@@ -81,6 +91,8 @@ export const tracklists: Tracklist[] = [
         genre: 'Trance',
         year: 2024,
         type: 'Bootleg',
+        imageUrl: 'https://picsum.photos/seed/t5/200/200',
+        previewUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-5.mp3',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- extend track data with image and preview URLs
- enable row expansion with image and audio preview
- style expanded section with new background and layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b097a187288332b2527f57f49ad9f1