### PR TITLE
feat: add energy bar and mood badges

### DIFF
--- a/frontend/src/tabs/Tracklist/TracklistTab.css
+++ b/frontend/src/tabs/Tracklist/TracklistTab.css
@@ -103,3 +103,25 @@
   border-left: 1px solid #444;
   padding-left: 8px;
 }
+
+.energy-bar {
+  background: #444;
+  height: 6px;
+  border-radius: 3px;
+  width: 60px;
+  overflow: hidden;
+}
+
+.energy-bar-fill {
+  background: #ffc107;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.mood-badge {
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  display: inline-block;
+}

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -1,7 +1,21 @@
 import { useState, useEffect, Fragment } from 'react'
 import './TracklistTab.css'
 import { tracklists, type Track } from './sampleData'
-import { FaStar, FaRegStar } from 'react-icons/fa'
+
+const moodColors: Record<string, string> = {
+  'mood 1': '#ff6b6b',
+  'mood 2': '#4dabf7',
+  'mood 3': '#51cf66',
+}
+
+const EnergyBar = ({ energy }: { energy: number }) => {
+  const percentage = (energy / 5) * 100
+  return (
+    <div className="energy-bar">
+      <div className="energy-bar-fill" style={{ width: `${percentage}%` }} />
+    </div>
+  )
+}
 
 const TracklistTab = () => {
   const [selectedId, setSelectedId] = useState(tracklists[0]?.id)
@@ -56,12 +70,6 @@ const TracklistTab = () => {
   const filteredTracklists = tracklists.filter(tl =>
     tl.name.toLowerCase().includes(searchTerm.toLowerCase())
   )
-
-  const renderStars = (count: number) => {
-    return Array.from({ length: 5 }, (_, i) =>
-      i < count ? <FaStar key={i} color="#ffc107" /> : <FaRegStar key={i} color="#555" />
-    )
-  }
 
   const handleSort = (column: SortKey) => {
     if (sortBy === column) {
@@ -167,8 +175,17 @@ const TracklistTab = () => {
                       {track.artists} - {track.title}
                     </td>
                     <td>{track.custom}</td>
-                    <td>{track.mood}</td>
-                    <td>{renderStars(track.energy)}</td>
+                    <td>
+                      <span
+                        className="mood-badge"
+                        style={{ backgroundColor: moodColors[track.mood] }}
+                      >
+                        {track.mood}
+                      </span>
+                    </td>
+                    <td>
+                      <EnergyBar energy={track.energy} />
+                    </td>
                     <td>{track.genre}</td>
                     <td>{track.year}</td>
                     <td>{track.type}</td>


### PR DESCRIPTION
## Summary
- replace star ratings with energy bar component
- add mood color badges in track table
- style energy bar and mood badges

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b09b00cc248332a4d5f83be05238a5