### PR TITLE
feat: mobile overlays for tracklist and filters

### DIFF
--- a/frontend/src/tabs/Tracklist/TracklistTab.css
+++ b/frontend/src/tabs/Tracklist/TracklistTab.css
@@ -125,3 +125,53 @@
   font-size: 0.8em;
   display: inline-block;
 }
+
+.mobile-controls {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .tracklists-panel,
+  .filter-panel {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 80%;
+    max-width: 300px;
+    background-color: #222;
+    overflow-y: auto;
+    z-index: 1000;
+    transition: transform 0.3s ease;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .tracklists-panel {
+    left: 0;
+    transform: translateX(-100%);
+  }
+
+  .tracklists-panel.open {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .filter-panel {
+    right: 0;
+    transform: translateX(100%);
+  }
+
+  .filter-panel.open {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .mobile-controls {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+}

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -27,6 +27,8 @@ const TracklistTab = () => {
   const [sortBy, setSortBy] = useState<SortKey>('index')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
   const [expandedTrack, setExpandedTrack] = useState<string | null>(null)
+  const [showTracklists, setShowTracklists] = useState(false)
+  const [showFilters, setShowFilters] = useState(false)
 
   const handleSelect = (id: string) => {
     setSelectedId(id)
@@ -86,7 +88,7 @@ const TracklistTab = () => {
 
   return (
     <div className="tracklist-container">
-      <aside className="tracklists-panel">
+      <aside className={`tracklists-panel ${showTracklists ? 'open' : ''}`}>
         <input
           className="search-input"
           type="text"
@@ -107,6 +109,10 @@ const TracklistTab = () => {
         </ul>
       </aside>
       <section className="tracks-panel">
+        <div className="mobile-controls">
+          <button onClick={() => setShowTracklists(prev => !prev)}>Listas</button>
+          <button onClick={() => setShowFilters(prev => !prev)}>Filtros</button>
+        </div>
         {loading ? (
           <div className="loading">Cargando...</div>
         ) : (
@@ -206,7 +212,7 @@ const TracklistTab = () => {
           </table>
         )}
       </section>
-      <aside className="filter-panel">
+      <aside className={`filter-panel ${showFilters ? 'open' : ''}`}>
         <label>
           Energía mínima
           <select value={minEnergy} onChange={e => setMinEnergy(Number(e.target.value))}>


### PR DESCRIPTION
## Summary
- add toggle buttons to show tracklists and filters as mobile overlays
- animate tracklists and filters with sliding panels for small screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b09c1749a08332ab8f8ed4bfba4020