### PR TITLE
Make 1001 tracklist list responsive

### DIFF
--- a/frontend/src/components/ResponsiveTable.css
+++ b/frontend/src/components/ResponsiveTable.css
@@ -1,0 +1,30 @@
+.responsive-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.responsive-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.responsive-table th,
+.responsive-table td {
+  padding: 8px;
+  text-align: left;
+}
+
+.responsive-table th {
+  background-color: #333;
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+@media (max-width: 600px) {
+  .responsive-table th,
+  .responsive-table td {
+    padding: 6px 4px;
+  }
+}

--- a/frontend/src/components/ResponsiveTable.tsx
+++ b/frontend/src/components/ResponsiveTable.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from 'react'
+import './ResponsiveTable.css'
+
+interface ResponsiveTableProps {
+  className?: string
+}
+
+const ResponsiveTable = ({ className, children }: PropsWithChildren<ResponsiveTableProps>) => (
+  <div className="responsive-table-wrapper">
+    <table className={`responsive-table ${className ?? ''}`.trim()}>
+      {children}
+    </table>
+  </div>
+)
+
+export default ResponsiveTable

--- a/frontend/src/tabs/Tracklist/TracklistTab.css
+++ b/frontend/src/tabs/Tracklist/TracklistTab.css
@@ -33,12 +33,6 @@
   flex: 1;
 }
 
-.tracks-panel th {
-  position: sticky;
-  top: 0;
-  background-color: #222;
-}
-
 .tracks-panel th.sortable {
   cursor: pointer;
 }

--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, Fragment } from 'react'
 import './TracklistTab.css'
 import { tracklists, type Track } from './sampleData'
+import ResponsiveTable from '../../components/ResponsiveTable'
 
 const moodColors: Record<string, string> = {
   'mood 1': '#ff6b6b',
@@ -116,7 +117,7 @@ const TracklistTab = () => {
         {loading ? (
           <div className="loading">Cargando...</div>
         ) : (
-          <table className="fade-in">
+          <ResponsiveTable className="fade-in">
             <thead>
               <tr>
                 <th
@@ -209,7 +210,7 @@ const TracklistTab = () => {
                 </Fragment>
               ))}
             </tbody>
-          </table>
+          </ResponsiveTable>
         )}
       </section>
       <aside className={`filter-panel ${showFilters ? 'open' : ''}`}>


### PR DESCRIPTION
## Summary
- add reusable `ResponsiveTable` component with sticky header and responsive container
- use new component in 1001Tracklist tab and remove dark header styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b0b425ca1883328049abbcd8b2558c