### PR TITLE
feat: add advanced track filters

### DIFF
--- a/frontend/src/tabs/Tracklist/TracklistTab.tsx
+++ b/frontend/src/tabs/Tracklist/TracklistTab.tsx
@@ -23,8 +23,23 @@ const TracklistTab = () => {
   const [tracks, setTracks] = useState<Track[]>(tracklists[0]?.tracks ?? [])
   const [loading, setLoading] = useState(false)
   const [minEnergy, setMinEnergy] = useState(0)
+  const [genreFilter, setGenreFilter] = useState('')
+  const [minTempo, setMinTempo] = useState('')
+  const [maxTempo, setMaxTempo] = useState('')
+  const [minYear, setMinYear] = useState('')
+  const [maxYear, setMaxYear] = useState('')
+  const [minDuration, setMinDuration] = useState('')
+  const [maxDuration, setMaxDuration] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
-  type SortKey = 'index' | 'theme' | 'custom' | 'mood' | 'energy' | 'genre' | 'year' | 'type'
+  type SortKey =
+    | 'index'
+    | 'theme'
+    | 'custom'
+    | 'mood'
+    | 'energy'
+    | 'genre'
+    | 'year'
+    | 'type'
   const [sortBy, setSortBy] = useState<SortKey>('index')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
   const [expandedTrack, setExpandedTrack] = useState<string | null>(null)
@@ -46,7 +61,18 @@ const TracklistTab = () => {
     return () => clearTimeout(timer)
   }, [selectedId])
 
-  const filteredTracks = tracks.filter(t => t.energy >= minEnergy)
+  const genres = Array.from(new Set(tracks.map(t => t.genre)))
+  const filteredTracks = tracks.filter(t => {
+    if (t.energy < minEnergy) return false
+    if (genreFilter && t.genre !== genreFilter) return false
+    if (minTempo && t.tempo < Number(minTempo)) return false
+    if (maxTempo && t.tempo > Number(maxTempo)) return false
+    if (minYear && t.year < Number(minYear)) return false
+    if (maxYear && t.year > Number(maxYear)) return false
+    if (minDuration && t.duration < Number(minDuration)) return false
+    if (maxDuration && t.duration > Number(maxDuration)) return false
+    return true
+  })
   const sortedTracks = (() => {
     const arr = [...filteredTracks]
     if (sortBy === 'index') {
@@ -224,6 +250,65 @@ const TracklistTab = () => {
             <option value={4}>4+</option>
             <option value={5}>5</option>
           </select>
+        </label>
+        <label>
+          Género
+          <select value={genreFilter} onChange={e => setGenreFilter(e.target.value)}>
+            <option value="">Todos</option>
+            {genres.map(g => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Tempo mínimo
+          <input
+            type="number"
+            value={minTempo}
+            onChange={e => setMinTempo(e.target.value)}
+          />
+        </label>
+        <label>
+          Tempo máximo
+          <input
+            type="number"
+            value={maxTempo}
+            onChange={e => setMaxTempo(e.target.value)}
+          />
+        </label>
+        <label>
+          Año mínimo
+          <input
+            type="number"
+            value={minYear}
+            onChange={e => setMinYear(e.target.value)}
+          />
+        </label>
+        <label>
+          Año máximo
+          <input
+            type="number"
+            value={maxYear}
+            onChange={e => setMaxYear(e.target.value)}
+          />
+        </label>
+        <label>
+          Duración mínima (s)
+          <input
+            type="number"
+            value={minDuration}
+            onChange={e => setMinDuration(e.target.value)}
+          />
+        </label>
+        <label>
+          Duración máxima (s)
+          <input
+            type="number"
+            value={maxDuration}
+            onChange={e => setMaxDuration(e.target.value)}
+          />
         </label>
       </aside>
     </div>

--- a/frontend/src/tabs/Tracklist/sampleData.ts
+++ b/frontend/src/tabs/Tracklist/sampleData.ts
@@ -5,6 +5,8 @@ export interface Track {
   custom: string
   mood: string
   energy: number
+  tempo: number
+  duration: number
   genre: string
   year: number
   type: string
@@ -30,6 +32,8 @@ export const tracklists: Tracklist[] = [
         custom: 'Rework',
         mood: 'mood 1',
         energy: 5,
+        tempo: 128,
+        duration: 210,
         genre: 'Pumping House',
         year: 2023,
         type: 'Original Mix',
@@ -43,6 +47,8 @@ export const tracklists: Tracklist[] = [
         custom: 'Edit',
         mood: 'mood 2',
         energy: 4,
+        tempo: 132,
+        duration: 180,
         genre: 'Techno',
         year: 2024,
         type: 'Remix',
@@ -56,6 +62,8 @@ export const tracklists: Tracklist[] = [
         custom: 'Mashup',
         mood: 'mood 3',
         energy: 3,
+        tempo: 140,
+        duration: 200,
         genre: 'Trance',
         year: 2023,
         type: 'Bootleg',
@@ -75,6 +83,8 @@ export const tracklists: Tracklist[] = [
         custom: 'Extended',
         mood: 'mood 1',
         energy: 2,
+        tempo: 125,
+        duration: 240,
         genre: 'House',
         year: 2022,
         type: 'Original Mix',
@@ -88,6 +98,8 @@ export const tracklists: Tracklist[] = [
         custom: 'Rework',
         mood: 'mood 2',
         energy: 5,
+        tempo: 138,
+        duration: 190,
         genre: 'Trance',
         year: 2024,
         type: 'Bootleg',


### PR DESCRIPTION
## Summary
- extend tracklist filter panel with genre, tempo, year and duration options
- store extra metadata in sample tracks to support new filters

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0bad36bdc8332b21e76128b191764