### PR TITLE
style: redesign ban tab layout

### DIFF
--- a/frontend/src/tabs/Ban/BanTab.css
+++ b/frontend/src/tabs/Ban/BanTab.css
@@ -1,0 +1,53 @@
+.ban-container {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.ban-section {
+  flex: 1;
+  min-width: 250px;
+}
+
+.path-input {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.path-input input[type='text'] {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid var(--muted-color);
+  border-radius: 4px;
+  background-color: var(--surface-color);
+  color: var(--text-color);
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--muted-color);
+  border-radius: 4px;
+  background-color: var(--surface-color);
+}
+
+.item-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid var(--muted-color);
+}
+
+.item-list li:last-child {
+  border-bottom: none;
+}
+
+@media (max-width: 600px) {
+  .ban-container {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import './BanTab.css'
 
 interface Item {
   id: number
@@ -40,15 +41,14 @@ const BanTab = () => {
   }
 
   return (
-    <div>
-      <section style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+    <div className="ban-container">
+      <section className="ban-section">
+        <div className="path-input">
           <input
             type="text"
             value={banPath}
             readOnly
             placeholder="Ruta BAN"
-            style={{ flex: 1 }}
           />
           <input
             type="file"
@@ -63,10 +63,10 @@ const BanTab = () => {
             ...
           </button>
         </div>
-        <ul>
+        <ul className="item-list">
           {banList.map(item => (
             <li key={item.id}>
-              {item.name}{' '}
+              <span>{item.name}</span>
               <button type="button" onClick={() => removeBan(item.id)}>
                 Eliminar
               </button>
@@ -75,14 +75,13 @@ const BanTab = () => {
         </ul>
       </section>
 
-      <section>
-        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+      <section className="ban-section">
+        <div className="path-input">
           <input
             type="text"
             value={unbanPath}
             readOnly
             placeholder="Ruta UNBAN"
-            style={{ flex: 1 }}
           />
           <input
             type="file"
@@ -97,10 +96,10 @@ const BanTab = () => {
             ...
           </button>
         </div>
-        <ul>
+        <ul className="item-list">
           {unbanList.map(item => (
             <li key={item.id}>
-              {item.name}{' '}
+              <span>{item.name}</span>
               <button type="button" onClick={() => removeUnban(item.id)}>
                 Eliminar
               </button>


### PR DESCRIPTION
## Summary
- place BAN and UNBAN selectors side by side with lists beneath
- style ban tab with responsive layout and list styling

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b4a7da687483328ddea7f5fe9cd25f