### PR TITLE
feat: add responsive ban/unban list with icons and alerts

### DIFF
--- a/frontend/src/tabs/Ban/BanTab.css
+++ b/frontend/src/tabs/Ban/BanTab.css
@@ -8,6 +8,8 @@
 .ban-section {
   flex: 1;
   min-width: 250px;
+  display: flex;
+  flex-direction: column;
 }
 
 .path-input {
@@ -32,9 +34,18 @@
   border: 1px solid var(--muted-color);
   border-radius: 4px;
   background-color: var(--surface-color);
+  flex: 1;
+  overflow-y: auto;
 }
 
-.item-list li {
+.letter-header {
+  padding: 8px;
+  font-weight: bold;
+  background-color: var(--muted-color);
+  color: var(--surface-color);
+}
+
+.item-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -42,8 +53,41 @@
   border-bottom: 1px solid var(--muted-color);
 }
 
-.item-list li:last-child {
+.item-row:last-child {
   border-bottom: none;
+}
+
+.item-remove {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.item-remove:hover {
+  color: var(--accent-color);
+}
+
+.ban-footer {
+  margin-top: 16px;
+  text-align: center;
+  padding: 8px;
+  border-top: 1px solid var(--muted-color);
+}
+
+.alert-box {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid var(--muted-color);
+  padding: 8px 16px;
+  border-radius: 4px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
+import { FaTrash } from 'react-icons/fa'
 import './BanTab.css'
 
 interface Item {
@@ -6,16 +7,47 @@ interface Item {
   name: string
 }
 
+const groupByLetter = (items: Item[]) =>
+  items.reduce<Record<string, Item[]>>((acc, item) => {
+    const letter = item.name.charAt(0).toUpperCase()
+    if (!acc[letter]) acc[letter] = []
+    acc[letter].push(item)
+    return acc
+  }, {})
+
 const BanTab = () => {
   const [banPath, setBanPath] = useState('')
   const [unbanPath, setUnbanPath] = useState('')
   const [banList, setBanList] = useState<Item[]>([
-    { id: 1, name: 'Baneo de prueba 1' },
-    { id: 2, name: 'Baneo de prueba 2' },
+    { id: 1, name: 'Alpha Song' },
+    { id: 2, name: 'Amanecer' },
+    { id: 3, name: 'Bravo Beat' },
+    { id: 4, name: 'Blue Sky' },
+    { id: 5, name: 'Crazy Tune' },
+    { id: 6, name: 'Crystal' },
+    { id: 7, name: 'Danza' },
+    { id: 8, name: 'Dreamer' },
+    { id: 9, name: 'Eclipse' },
+    { id: 10, name: 'Emerald' },
+    { id: 11, name: 'Fuego' },
+    { id: 12, name: 'Fiesta' },
   ])
   const [unbanList, setUnbanList] = useState<Item[]>([
-    { id: 3, name: 'Unban de prueba 1' },
+    { id: 13, name: 'Azul' },
+    { id: 14, name: 'Alfa' },
+    { id: 15, name: 'Brisa' },
+    { id: 16, name: 'Barco' },
+    { id: 17, name: 'Corazon' },
+    { id: 18, name: 'Cielo' },
+    { id: 19, name: 'Diamante' },
+    { id: 20, name: 'Dragon' },
+    { id: 21, name: 'Estrella' },
+    { id: 22, name: 'Espada' },
+    { id: 23, name: 'Faro' },
+    { id: 24, name: 'Flota' },
   ])
+
+  const [showAlert, setShowAlert] = useState(false)
 
   const banInputRef = useRef<HTMLInputElement>(null)
   const unbanInputRef = useRef<HTMLInputElement>(null)
@@ -40,38 +72,60 @@ const BanTab = () => {
     setUnbanList(prev => prev.filter(item => item.id !== id))
   }
 
+  useEffect(() => {
+    setShowAlert(true)
+    const timer = setTimeout(() => setShowAlert(false), 3000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  const groupedBan = groupByLetter(banList)
+  const groupedUnban = groupByLetter(unbanList)
+
   return (
-    <div className="ban-container">
-      <section className="ban-section">
-        <div className="path-input">
-          <input
-            type="text"
-            value={banPath}
-            readOnly
-            placeholder="Ruta BAN"
-          />
-          <input
-            type="file"
-            ref={banInputRef}
-            style={{ display: 'none' }}
-            onChange={e => handleFolderChange(e, setBanPath)}
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore: permitir selección de carpetas
-            webkitdirectory=""
-          />
-          <button type="button" onClick={() => banInputRef.current?.click()}>
-            ...
-          </button>
-        </div>
+    <>
+      <div className="ban-container">
+        <section className="ban-section">
+          <div className="path-input">
+            <input
+              type="text"
+              value={banPath}
+              readOnly
+              placeholder="Ruta BAN"
+            />
+            <input
+              type="file"
+              ref={banInputRef}
+              style={{ display: 'none' }}
+              onChange={e => handleFolderChange(e, setBanPath)}
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore: permitir selección de carpetas
+              webkitdirectory=""
+            />
+            <button type="button" onClick={() => banInputRef.current?.click()}>
+              ...
+            </button>
+          </div>
         <ul className="item-list">
-          {banList.map(item => (
-            <li key={item.id}>
-              <span>{item.name}</span>
-              <button type="button" onClick={() => removeBan(item.id)}>
-                Eliminar
-              </button>
-            </li>
-          ))}
+          {Object.entries(groupedBan)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([letter, items]) => (
+              <Fragment key={letter}>
+                <li className="letter-header">{letter}</li>
+                {items.map(item => (
+                  <li key={item.id} className="item-row">
+                    <span>{item.name}</span>
+                    <button
+                      type="button"
+                      className="item-remove"
+                      onClick={() => removeBan(item.id)}
+                      aria-label={`Eliminar ${item.name}`}
+                    >
+                      <FaTrash />
+                    </button>
+                  </li>
+                ))}
+              </Fragment>
+            ))}
         </ul>
       </section>
 
@@ -97,17 +151,36 @@ const BanTab = () => {
           </button>
         </div>
         <ul className="item-list">
-          {unbanList.map(item => (
-            <li key={item.id}>
-              <span>{item.name}</span>
-              <button type="button" onClick={() => removeUnban(item.id)}>
-                Eliminar
-              </button>
-            </li>
-          ))}
+          {Object.entries(groupedUnban)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([letter, items]) => (
+              <Fragment key={letter}>
+                <li className="letter-header">{letter}</li>
+                {items.map(item => (
+                  <li key={item.id} className="item-row">
+                    <span>{item.name}</span>
+                    <button
+                      type="button"
+                      className="item-remove"
+                      onClick={() => removeUnban(item.id)}
+                      aria-label={`Eliminar ${item.name}`}
+                    >
+                      <FaTrash />
+                    </button>
+                  </li>
+                ))}
+              </Fragment>
+            ))}
         </ul>
       </section>
-    </div>
+      </div>
+      <footer className="ban-footer">Información de la pantalla BAN/UNBAN</footer>
+      {showAlert && (
+        <div className="alert-box">
+          Cargados {banList.length} BAN y {unbanList.length} UNBAN
+        </div>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- group Ban and Unban items alphabetically and populate with many demo entries
- replace delete buttons with react-icons and add footer and load alert
- style tab for responsiveness, grouped headings and alert box

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b4acf021048332b6d9ac08ffecc372