### PR TITLE
Enhance BAN tab inputs and list styling

### DIFF
--- a/frontend/src/tabs/Ban/BanTab.css
+++ b/frontend/src/tabs/Ban/BanTab.css
@@ -14,17 +14,43 @@
 
 .path-input {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-bottom: 8px;
+  position: relative;
+}
+
+.path-input .input-icon {
+  position: absolute;
+  left: 10px;
+  color: var(--muted-color);
+  pointer-events: none;
 }
 
 .path-input input[type='text'] {
   flex: 1;
-  padding: 8px;
+  padding: 8px 8px 8px 32px;
   border: 1px solid var(--muted-color);
-  border-radius: 4px;
+  border-radius: 8px;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.path-input button {
+  border: 1px solid var(--muted-color);
   background-color: var(--surface-color);
   color: var(--text-color);
+  border-radius: 8px;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.path-input button:hover {
+  background-color: var(--muted-color);
+  color: var(--surface-color);
 }
 
 .item-list {
@@ -32,10 +58,11 @@
   padding: 0;
   margin: 0;
   border: 1px solid var(--muted-color);
-  border-radius: 4px;
+  border-radius: 8px;
   background-color: var(--surface-color);
   flex: 1;
   overflow-y: auto;
+  max-height: 300px;
 }
 
 .letter-header {
@@ -45,16 +72,26 @@
   color: var(--surface-color);
 }
 
+
 .item-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--muted-color);
+}
+
+.item-row:nth-child(odd) {
+  background-color: var(--bg-color);
 }
 
 .item-row:last-child {
   border-bottom: none;
+}
+
+.item-row:hover {
+  background-color: var(--muted-color);
+  color: var(--surface-color);
 }
 
 .item-remove {

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { FaTrash } from 'react-icons/fa'
+import { FaTrash, FaFolder, FaFolderOpen } from 'react-icons/fa'
 import './BanTab.css'
 
 interface Item {
@@ -86,6 +86,7 @@ const BanTab = () => {
       <div className="ban-container">
         <section className="ban-section">
           <div className="path-input">
+            <FaFolder className="input-icon" />
             <input
               type="text"
               value={banPath}
@@ -101,8 +102,12 @@ const BanTab = () => {
               // @ts-ignore: permitir selección de carpetas
               webkitdirectory=""
             />
-            <button type="button" onClick={() => banInputRef.current?.click()}>
-              ...
+            <button
+              type="button"
+              aria-label="Seleccionar carpeta BAN"
+              onClick={() => banInputRef.current?.click()}
+            >
+              <FaFolderOpen />
             </button>
           </div>
         <ul className="item-list">
@@ -131,6 +136,7 @@ const BanTab = () => {
 
       <section className="ban-section">
         <div className="path-input">
+          <FaFolder className="input-icon" />
           <input
             type="text"
             value={unbanPath}
@@ -146,8 +152,12 @@ const BanTab = () => {
             // @ts-ignore: permitir selección de carpetas
             webkitdirectory=""
           />
-          <button type="button" onClick={() => unbanInputRef.current?.click()}>
-            ...
+          <button
+            type="button"
+            aria-label="Seleccionar carpeta UNBAN"
+            onClick={() => unbanInputRef.current?.click()}
+          >
+            <FaFolderOpen />
           </button>
         </div>
         <ul className="item-list">


### PR DESCRIPTION
## Summary
- Add FontAwesome folder icons to BAN/UNBAN path inputs and browse buttons
- Restyle path inputs with rounded grey backgrounds
- Make BAN lists scrollable with improved row styling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b4afc206ac83328e1f539ae1d4d00b