### PR TITLE
feat: add confirmation and undo for BAN/UNBAN lists

### DIFF
--- a/frontend/src/tabs/Ban/BanTab.css
+++ b/frontend/src/tabs/Ban/BanTab.css
@@ -127,6 +127,23 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
+.undo-button {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  background-color: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid var(--muted-color);
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.undo-button:hover {
+  background-color: var(--muted-color);
+  color: var(--surface-color);
+}
+
 @media (max-width: 600px) {
   .ban-container {
     flex-direction: column;

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -49,6 +49,9 @@ const BanTab = () => {
 
   const [searchTerm, setSearchTerm] = useState('')
   const [showAlert, setShowAlert] = useState(false)
+  const [lastRemoved, setLastRemoved] = useState<
+    { item: Item; from: 'ban' | 'unban' } | null
+  >(null)
 
   const banInputRef = useRef<HTMLInputElement>(null)
   const unbanInputRef = useRef<HTMLInputElement>(null)
@@ -66,11 +69,29 @@ const BanTab = () => {
   }
 
   const removeBan = (id: number) => {
-    setBanList(prev => prev.filter(item => item.id !== id))
+    const item = banList.find(i => i.id === id)
+    if (item && window.confirm(`¿Eliminar ${item.name}?`)) {
+      setBanList(prev => prev.filter(i => i.id !== id))
+      setLastRemoved({ item, from: 'ban' })
+    }
   }
 
   const removeUnban = (id: number) => {
-    setUnbanList(prev => prev.filter(item => item.id !== id))
+    const item = unbanList.find(i => i.id === id)
+    if (item && window.confirm(`¿Eliminar ${item.name}?`)) {
+      setUnbanList(prev => prev.filter(i => i.id !== id))
+      setLastRemoved({ item, from: 'unban' })
+    }
+  }
+
+  const undoRemove = () => {
+    if (!lastRemoved) return
+    if (lastRemoved.from === 'ban') {
+      setBanList(prev => [...prev, lastRemoved.item])
+    } else {
+      setUnbanList(prev => [...prev, lastRemoved.item])
+    }
+    setLastRemoved(null)
   }
 
   useEffect(() => {
@@ -217,6 +238,11 @@ const BanTab = () => {
         <div className="alert-box">
           Cargados {banList.length} BAN y {unbanList.length} UNBAN
         </div>
+      )}
+      {lastRemoved && (
+        <button type="button" className="undo-button" onClick={undoRemove}>
+          Deshacer
+        </button>
       )}
     </>
   )


### PR DESCRIPTION
## Summary
- add confirmation dialogs when removing BAN or UNBAN entries
- add undo button to restore last removed item with styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b4b45561f08332aa910a6963409ae3