### PR TITLE
Validate manually entered folder paths in ban tab

### DIFF
--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -237,7 +237,10 @@ const BanTab = () => {
                 className="form-control"
                 value={banPath}
                 onChange={e => setBanPath(e.target.value)}
-                onBlur={() => checkPath(banPath, 'BAN')}
+                onBlur={e => checkPath(e.target.value, 'BAN')}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') checkPath(e.currentTarget.value, 'BAN')
+                }}
                 placeholder="Ruta BAN"
               />
               <input
@@ -332,7 +335,11 @@ const BanTab = () => {
                 className="form-control"
                 value={unbanPath}
                 onChange={e => setUnbanPath(e.target.value)}
-                onBlur={() => checkPath(unbanPath, 'UNBAN')}
+                onBlur={e => checkPath(e.target.value, 'UNBAN')}
+                onKeyDown={e => {
+                  if (e.key === 'Enter')
+                    checkPath(e.currentTarget.value, 'UNBAN')
+                }}
                 placeholder="Ruta UNBAN"
               />
               <input


### PR DESCRIPTION
## Summary
- verify BAN and UNBAN folders when user types a path manually
- warn on Enter or blur if the directory doesn't exist

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b56627ded88332a7c121fb7646d606