### PR TITLE
Add FastAPI backend for ban/unban management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Application data
+backend/ban_paths.yaml

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,163 @@
+"""FastAPI application for managing allowed and banned names.
+
+This API exposes endpoints to read and modify the `allowed_names` and
+`banned_names` tables stored in the local SQLite database.  It also
+provides endpoints for persisting the BAN/UNBAN directory paths in a
+YAML file so the frontend can restore the previously selected paths.
+
+The endpoints are secured using a simple API key that must be supplied
+in the `X-API-Key` header.  The expected key should be stored in the
+`API_KEY` environment variable when the application is executed.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import List
+
+import yaml
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.security import APIKeyHeader
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+BASE_DIR = Path(__file__).resolve().parent
+DB_PATH = BASE_DIR / "database" / "logs.db"
+CONFIG_PATH = BASE_DIR / "ban_paths.yaml"
+
+API_KEY = os.getenv("API_KEY")
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def verify_api_key(api_key: str | None = Security(api_key_header)) -> bool:
+    """Dependency that verifies the provided API key."""
+    if API_KEY and api_key == API_KEY:
+        return True
+    raise HTTPException(status_code=401, detail="Invalid or missing API Key")
+
+
+app = FastAPI(title="TrackMind Ban API")
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+def get_connection() -> sqlite3.Connection:
+    """Return a new SQLite3 connection with safe defaults."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = lambda cursor, row: row[0]
+    return conn
+
+
+def fetch_names(table: str) -> List[str]:
+    """Fetch all names from the specified table ordered alphabetically."""
+    with get_connection() as conn:
+        cursor = conn.execute(f"SELECT name FROM {table} ORDER BY name")
+        return list(cursor.fetchall())
+
+
+def move_name(source: str, dest: str, name: str) -> None:
+    """Move a name from source table to destination table."""
+    with get_connection() as conn:
+        conn.execute(f"DELETE FROM {source} WHERE name = ?", (name,))
+        conn.execute(f"INSERT OR IGNORE INTO {dest}(name) VALUES (?)", (name,))
+        conn.commit()
+
+
+def delete_name(table: str, name: str) -> None:
+    with get_connection() as conn:
+        conn.execute(f"DELETE FROM {table} WHERE name = ?", (name,))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class NameItem(BaseModel):
+    name: str
+
+
+class Paths(BaseModel):
+    ban_path: str
+    unban_path: str
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/allowed", dependencies=[Depends(verify_api_key)])
+async def get_allowed() -> dict:
+    """Return all allowed names."""
+    return {"allowed": fetch_names("allowed_names")}
+
+
+@app.get("/banned", dependencies=[Depends(verify_api_key)])
+async def get_banned() -> dict:
+    """Return all banned names."""
+    return {"banned": fetch_names("banned_names")}
+
+
+@app.post("/ban", dependencies=[Depends(verify_api_key)])
+async def ban_name(item: NameItem) -> dict:
+    """Move a name from allowed_names to banned_names."""
+    move_name("allowed_names", "banned_names", item.name)
+    return {"status": "banned", "name": item.name}
+
+
+@app.post("/unban", dependencies=[Depends(verify_api_key)])
+async def unban_name(item: NameItem) -> dict:
+    """Move a name from banned_names to allowed_names."""
+    move_name("banned_names", "allowed_names", item.name)
+    return {"status": "unbanned", "name": item.name}
+
+
+@app.delete("/allowed/{name}", dependencies=[Depends(verify_api_key)])
+async def delete_allowed(name: str) -> dict:
+    """Delete a name from the allowed_names table."""
+    delete_name("allowed_names", name)
+    return {"status": "deleted", "table": "allowed", "name": name}
+
+
+@app.delete("/banned/{name}", dependencies=[Depends(verify_api_key)])
+async def delete_banned(name: str) -> dict:
+    """Delete a name from the banned_names table."""
+    delete_name("banned_names", name)
+    return {"status": "deleted", "table": "banned", "name": name}
+
+
+# ---------------------------------------------------------------------------
+# Configuration file endpoints
+# ---------------------------------------------------------------------------
+
+
+def read_paths() -> Paths:
+    if CONFIG_PATH.exists():
+        with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    else:
+        data = {}
+    return Paths(ban_path=data.get("ban_path", ""), unban_path=data.get("unban_path", ""))
+
+
+@app.get("/paths", dependencies=[Depends(verify_api_key)])
+async def get_paths() -> dict:
+    """Return the saved BAN and UNBAN paths from the YAML file."""
+    return read_paths().model_dump()
+
+
+@app.post("/paths", dependencies=[Depends(verify_api_key)])
+async def save_paths(paths: Paths) -> dict:
+    """Persist BAN and UNBAN paths to the YAML configuration file."""
+    with CONFIG_PATH.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(paths.model_dump(), fh)
+    return {"status": "saved"}
+
+
+# The application can be served using: uvicorn backend.api:app --reload

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn[standard]>=0.23
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add FastAPI app to expose allowed and banned name lists
- enable moving/removing names and persisting ban/unban paths
- document dependencies and ignore generated YAML config

## Testing
- `python -m py_compile backend/api.py`
- `python - <<'PY'
import os
os.environ['API_KEY']='testkey'
from fastapi.testclient import TestClient
from backend.api import app, DB_PATH, CONFIG_PATH
import sqlite3
client=TestClient(app)
headers={'X-API-Key':'testkey'}
conn=sqlite3.connect(DB_PATH)
cur=conn.cursor()
cur.execute('SELECT name FROM allowed_names LIMIT 1')
allowed_name=cur.fetchone()[0]
conn.close()
print('allowed_name', allowed_name)
print('allowed count', len(client.get('/allowed', headers=headers).json()['allowed']))
print('banned count', len(client.get('/banned', headers=headers).json()['banned']))
client.post('/ban', headers=headers, json={'name': allowed_name})
print('after ban allowed count', len(client.get('/allowed', headers=headers).json()['allowed']))
print('after ban banned top', client.get('/banned', headers=headers).json()['banned'][:3])
client.post('/unban', headers=headers, json={'name': allowed_name})
print('after unban allowed count', len(client.get('/allowed', headers=headers).json()['allowed']))
if CONFIG_PATH.exists():
    CONFIG_PATH.unlink()
print('initial paths', client.get('/paths', headers=headers).json())
client.post('/paths', headers=headers, json={'ban_path': '/tmp/ban', 'unban_path': '/tmp/unban'})
print('saved paths', client.get('/paths', headers=headers).json())
PY`

------
https://chatgpt.com/codex/tasks/task_b_68b5754d45d0833299b1fab68868b3db