### PR TITLE
Add FastAPI entry point for backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+"""Entry point for starting the FastAPI application with uvicorn.
+
+This module simply exposes the FastAPI ``app`` defined in ``api.py`` so
+that it can be referenced as ``main:app`` when launching uvicorn from the
+``backend`` directory.
+"""
+
+from api import app


### PR DESCRIPTION
## Summary
- expose FastAPI app via new `backend/main.py` so Electron startup can run `uvicorn main:app`

## Testing
- `python -m py_compile api.py main.py`
- `timeout 5s python -m uvicorn main:app --host 127.0.0.1 --port 8000`

------
https://chatgpt.com/codex/tasks/task_b_68b595dc8418833289f9130c448e6f19