### PR TITLE
Use Electron dialog for folder selection in BanTab

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,5 +1,5 @@
 // desktop/main.js
-const { app, BrowserWindow, dialog, Menu } = require("electron");
+const { app, BrowserWindow, dialog, Menu, ipcMain } = require("electron");
 const path = require("path");
 const { spawn } = require("child_process");
 const kill = require("tree-kill");
@@ -12,6 +12,15 @@ let viteProc = null;
 const FRONTEND_URL = "http://localhost:5173";
 const BACKEND_HOST = "127.0.0.1";
 const BACKEND_PORT = 8000;
+
+ipcMain.handle("select-directory", async () => {
+    const result = await dialog.showOpenDialog({
+        properties: ["openDirectory"],
+    });
+    return result.canceled || result.filePaths.length === 0
+        ? null
+        : result.filePaths[0];
+});
 
 function fileExists(p) {
     try {
@@ -151,7 +160,11 @@ function createWindow() {
     const win = new BrowserWindow({
         width: 1000,
         height: 700,
-        webPreferences: { nodeIntegration: false, contextIsolation: true },
+        webPreferences: {
+            nodeIntegration: false,
+            contextIsolation: true,
+            preload: path.join(__dirname, "preload.js"),
+        },
     });
 
     win.loadURL(FRONTEND_URL).catch((err) => {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+    selectDirectory: () => ipcRenderer.invoke('select-directory'),
+});

--- a/frontend/src/electron.d.ts
+++ b/frontend/src/electron.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  interface Window {
+    electronAPI?: {
+      selectDirectory: () => Promise<string | null>;
+    };
+  }
+}

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -101,29 +101,14 @@ const BanTab = () => {
     return true
   }
 
-  const handleFolderChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
+  const handleFolderSelect = async (
     setter: React.Dispatch<React.SetStateAction<string>>,
     type: 'BAN' | 'UNBAN',
   ) => {
-    const files = e.target.files
-    if (files && files.length > 0) {
-      const file = files[0] as File & { path?: string; webkitRelativePath?: string }
-      let folderPath = ''
-      if (file.path) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const pathModule = (window as any).require?.('path')
-        folderPath = pathModule
-          ? pathModule.dirname(file.path)
-          : file.path.replace(/[/\\][^/\\]*$/, '')
-      } else if (file.webkitRelativePath) {
-        folderPath = file.webkitRelativePath.split('/')[0]
-      } else {
-        folderPath = file.name
-      }
+    const folderPath = await window.electronAPI?.selectDirectory()
+    if (folderPath) {
       setter(folderPath)
       await checkPath(folderPath, type)
-      e.target.value = ''
     }
   }
 
@@ -307,23 +292,14 @@ const BanTab = () => {
                 }}
                 placeholder="Ruta BAN"
               />
-              <input
-                id="ban-folder"
-                type="file"
-                style={{ display: 'none' }}
-                onChange={e => handleFolderChange(e, setBanPath, 'BAN')}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore: permitir selección de carpetas
-                webkitdirectory=""
-              />
-              <label
-                htmlFor="ban-folder"
+              <button
+                type="button"
                 aria-label="Seleccionar carpeta BAN"
-                tabIndex={0}
                 className="input-group-text btn btn-primary"
+                onClick={() => handleFolderSelect(setBanPath, 'BAN')}
               >
                 <FaFolderOpen />
-              </label>
+              </button>
             </div>
             <div className="input-group mb-2">
               <span className="input-group-text">
@@ -405,23 +381,14 @@ const BanTab = () => {
                 }}
                 placeholder="Ruta UNBAN"
               />
-              <input
-                id="unban-folder"
-                type="file"
-                style={{ display: 'none' }}
-                onChange={e => handleFolderChange(e, setUnbanPath, 'UNBAN')}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore: permitir selección de carpetas
-                webkitdirectory=""
-              />
-              <label
-                htmlFor="unban-folder"
+              <button
+                type="button"
                 aria-label="Seleccionar carpeta UNBAN"
-                tabIndex={0}
                 className="input-group-text btn btn-primary"
+                onClick={() => handleFolderSelect(setUnbanPath, 'UNBAN')}
               >
                 <FaFolderOpen />
-              </label>
+              </button>
             </div>
             <div className="input-group mb-2">
               <span className="input-group-text">


### PR DESCRIPTION
## Summary
- use Electron's `dialog.showOpenDialog` to pick directories
- replace hidden file inputs with buttons that invoke the folder dialog
- expose `selectDirectory` IPC from the main process via a preload script

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint` (frontend)
- `npm run build` (frontend)
- `npm test` (desktop) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68b5bd7346ac8332af17fd9bb0f8c3f6