### PR TITLE
feat(frontend): use Bootstrap collapse and Font Awesome icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.5.2",
         "bootstrap": "^5.3.8",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1",
-        "react-icons": "^5.5.0"
+        "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -917,6 +917,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2919,15 +2928,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "bootstrap": "^5.3.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-icons": "^5.5.0"
+    "@fortawesome/fontawesome-free": "^6.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -3,13 +3,8 @@
   flex-direction: column;
   background-color: var(--surface-color);
   color: var(--text-color);
-  width: 200px;
   height: 100vh;
-  transition: width 0.3s;
-}
-
-.sidebar--collapsed {
-  width: 60px;
+  width: 100%;
 }
 
 .sidebar__header {
@@ -31,12 +26,11 @@
 }
 
 .sidebar__toggle {
-  margin-left: auto;
   background: none;
   border: none;
   color: inherit;
   cursor: pointer;
-  padding: 4px;
+  padding: 12px;
 }
 
 .sidebar__nav {
@@ -55,6 +49,7 @@
   align-items: center;
   gap: 8px;
   text-align: left;
+  width: 100%;
 }
 
 .sidebar__tab--active {
@@ -72,15 +67,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
 }
 
-.sidebar--collapsed .sidebar__name,
-.sidebar--collapsed .sidebar__tab span,
-.sidebar--collapsed .sidebar__settings span {
-  display: none;
-}
-
-.sidebar--collapsed .sidebar__tab,
-.sidebar--collapsed .sidebar__settings {
-  justify-content: center;
-}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,4 @@
-import { useState } from 'react'
 import './Sidebar.css'
-import { FaMusic, FaList, FaBan, FaEllipsisH, FaBars } from 'react-icons/fa'
-import type { IconType } from 'react-icons'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
 
@@ -13,33 +10,33 @@ interface SidebarProps {
 
 const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
 
-const tabIcons: Record<Tab, IconType> = {
-  BEATPORT: FaMusic,
-  '1001TRACKLIST': FaList,
-  'BAN/UNBAN': FaBan,
-  OTROS: FaEllipsisH,
+const tabIcons: Record<Tab, string> = {
+  BEATPORT: 'fa-solid fa-music',
+  '1001TRACKLIST': 'fa-solid fa-list',
+  'BAN/UNBAN': 'fa-solid fa-ban',
+  OTROS: 'fa-solid fa-ellipsis-h',
 }
 
-const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
-  const [collapsed, setCollapsed] = useState(false)
-
-  return (
-    <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
-      <div className="sidebar__header">
-        <div className="sidebar__avatar" />
-        {!collapsed && <span className="sidebar__name">GORKA</span>}
-        <button
-          className="sidebar__toggle"
-          onClick={() => setCollapsed(p => !p)}
-          aria-label={collapsed ? 'Expandir menú' : 'Colapsar menú'}
-        >
-          <FaBars />
-        </button>
-      </div>
-      <nav className="sidebar__nav" role="tablist">
-        {tabs.map(tab => {
-          const Icon = tabIcons[tab]
-          return (
+const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => (
+  <div className="d-flex">
+    <button
+      className="sidebar__toggle btn btn-link"
+      type="button"
+      data-bs-toggle="collapse"
+      data-bs-target="#sidebarMenu"
+      aria-controls="sidebarMenu"
+      aria-label="Alternar menú"
+    >
+      <i className="fa-solid fa-bars" />
+    </button>
+    <div className="collapse collapse-horizontal show" id="sidebarMenu" style={{ width: '200px' }}>
+      <aside className="sidebar">
+        <div className="sidebar__header">
+          <div className="sidebar__avatar" />
+          <span className="sidebar__name">GORKA</span>
+        </div>
+        <nav className="sidebar__nav" role="tablist">
+          {tabs.map(tab => (
             <button
               key={tab}
               className={`sidebar__tab${activeTab === tab ? ' sidebar__tab--active' : ''}`}
@@ -47,25 +44,19 @@ const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
               role="tab"
               aria-selected={activeTab === tab}
             >
-              <Icon />
-              {!collapsed && <span>{tab}</span>}
+              <i className={tabIcons[tab]} />
+              <span>{tab}</span>
             </button>
-          )
-        })}
-      </nav>
-      <button className="sidebar__settings" aria-label="Abrir configuración" onClick={onSettingsClick}>
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path
-            fillRule="evenodd"
-            d="M11.983 2.083a1 1 0 0 1 1.935 0l.342 1.094a1 1 0 0 0 .95.694h1.154a1 1 0 0 1 .986 1.164l-.223 1.274a1 1 0 0 0 .271.907l.817.817a1 1 0 0 1 0 1.414l-.817.817a1 1 0 0 0-.271.907l.223 1.274a1 1 0 0 1-.986 1.164h-1.154a1 1 0 0 0-.95.694l-.342 1.094a1 1 0 0 1-1.935 0l-.342-1.094a1 1 0 0 0-.95-.694H9.537a1 1 0 0 1-.986-1.164l.223-1.274a1 1 0 0 0-.271-.907l-.817-.817a1 1 0 0 1 0-1.414l.817-.817a1 1 0 0 0 .271-.907L8.55 5.035A1 1 0 0 1 9.537 3.87h1.154a1 1 0 0 0 .95-.694l.342-1.094zM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-            clipRule="evenodd"
-          />
-        </svg>
-        {!collapsed && <span>Configuración</span>}
-      </button>
-    </aside>
-  )
-}
+          ))}
+        </nav>
+        <button className="sidebar__settings" aria-label="Abrir configuración" onClick={onSettingsClick}>
+          <i className="fa-solid fa-gear" />
+          <span>Configuración</span>
+        </button>
+      </aside>
+    </div>
+  </div>
+)
 
 export default Sidebar
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap/dist/js/bootstrap.bundle.min.js'
+import '@fortawesome/fontawesome-free/css/all.min.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -1,5 +1,4 @@
 import { Fragment, useEffect, useState } from 'react'
-import { FaTrash, FaFolder, FaFolderOpen, FaSearch } from 'react-icons/fa'
 import './BanTab.css'
 import { apiFetch } from '../../utils/api'
 
@@ -279,7 +278,7 @@ const BanTab = () => {
           <section className="col-md-6 d-flex flex-column">
             <div className="input-group mb-2">
               <span className="input-group-text">
-                <FaFolder />
+                <i className="fa-solid fa-folder" />
               </span>
               <input
                 type="text"
@@ -298,12 +297,12 @@ const BanTab = () => {
                 className="input-group-text btn btn-primary"
                 onClick={() => handleFolderSelect(setBanPath, 'BAN')}
               >
-                <FaFolderOpen />
+                <i className="fa-solid fa-folder-open" />
               </button>
             </div>
             <div className="input-group mb-2">
               <span className="input-group-text">
-                <FaSearch />
+                <i className="fa-solid fa-search" />
               </span>
               <input
                 type="search"
@@ -347,14 +346,14 @@ const BanTab = () => {
                         onDragEnd={() => setDragged(null)}
                       >
                         <span>{item.name}</span>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-secondary"
-                          onClick={() => removeBan(item.id)}
-                          aria-label={`Eliminar ${item.name}`}
-                        >
-                          <FaTrash />
-                        </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-secondary"
+                        onClick={() => removeBan(item.id)}
+                        aria-label={`Eliminar ${item.name}`}
+                      >
+                        <i className="fa-solid fa-trash" />
+                      </button>
                       </li>
                     ))}
                   </Fragment>
@@ -367,7 +366,7 @@ const BanTab = () => {
           <section className="col-md-6 d-flex flex-column">
             <div className="input-group mb-2">
               <span className="input-group-text">
-                <FaFolder />
+                <i className="fa-solid fa-folder" />
               </span>
               <input
                 type="text"
@@ -387,12 +386,12 @@ const BanTab = () => {
                 className="input-group-text btn btn-primary"
                 onClick={() => handleFolderSelect(setUnbanPath, 'UNBAN')}
               >
-                <FaFolderOpen />
+                <i className="fa-solid fa-folder-open" />
               </button>
             </div>
             <div className="input-group mb-2">
               <span className="input-group-text">
-                <FaSearch />
+                <i className="fa-solid fa-search" />
               </span>
               <input
                 type="search"
@@ -440,7 +439,7 @@ const BanTab = () => {
                           onClick={() => removeUnban(item.id)}
                           aria-label={`Eliminar ${item.name}`}
                         >
-                          <FaTrash />
+                          <i className="fa-solid fa-trash" />
                         </button>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary
- replace sidebar icons with Font Awesome and add smooth Bootstrap collapse
- include Font Awesome assets and remove react-icons usage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5c8c687408332b6d4debc011ddce1