### PR TITLE
feat: make sidebar collapsible

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -4,7 +4,13 @@
   background-color: var(--surface-color);
   color: var(--text-color);
   height: 100vh;
-  width: 100%;
+  width: 200px;
+  transition: width 0.3s;
+  overflow: hidden;
+}
+
+.sidebar--collapsed {
+  width: 60px;
 }
 
 .sidebar__header {
@@ -31,6 +37,7 @@
   color: inherit;
   cursor: pointer;
   padding: 12px;
+  align-self: flex-end;
 }
 
 .sidebar__nav {
@@ -68,5 +75,10 @@
   align-items: center;
   gap: 8px;
   width: 100%;
+}
+
+.sidebar--collapsed .sidebar__tab,
+.sidebar--collapsed .sidebar__settings {
+  justify-content: center;
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import './Sidebar.css'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -17,46 +18,49 @@ const tabIcons: Record<Tab, string> = {
   OTROS: 'fa-solid fa-ellipsis-h',
 }
 
-const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => (
-  <div className="d-flex">
-    <button
-      className="sidebar__toggle btn btn-link"
-      type="button"
-      data-bs-toggle="collapse"
-      data-bs-target="#sidebarMenu"
-      aria-controls="sidebarMenu"
-      aria-label="Alternar menú"
-    >
-      <i className="fa-solid fa-bars" />
-    </button>
-    <div className="collapse collapse-horizontal show" id="sidebarMenu" style={{ width: '200px' }}>
-      <aside className="sidebar">
+const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
+  const [collapsed, setCollapsed] = useState(false)
+
+  return (
+    <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
+      <button
+        className="sidebar__toggle"
+        aria-label="Alternar menú"
+        onClick={() => setCollapsed(prev => !prev)}
+      >
+        <i className={`fa-solid ${collapsed ? 'fa-chevron-right' : 'fa-chevron-left'}`} />
+      </button>
+      {!collapsed && (
         <div className="sidebar__header">
           <div className="sidebar__avatar" />
           <span className="sidebar__name">GORKA</span>
         </div>
-        <nav className="sidebar__nav" role="tablist">
-          {tabs.map(tab => (
-            <button
-              key={tab}
-              className={`sidebar__tab${activeTab === tab ? ' sidebar__tab--active' : ''}`}
-              onClick={() => onTabChange(tab)}
-              role="tab"
-              aria-selected={activeTab === tab}
-            >
-              <i className={tabIcons[tab]} />
-              <span>{tab}</span>
-            </button>
-          ))}
-        </nav>
-        <button className="sidebar__settings" aria-label="Abrir configuración" onClick={onSettingsClick}>
-          <i className="fa-solid fa-gear" />
-          <span>Configuración</span>
-        </button>
-      </aside>
-    </div>
-  </div>
-)
+      )}
+      <nav className="sidebar__nav" role="tablist">
+        {tabs.map(tab => (
+          <button
+            key={tab}
+            className={`sidebar__tab${activeTab === tab ? ' sidebar__tab--active' : ''}`}
+            onClick={() => onTabChange(tab)}
+            role="tab"
+            aria-selected={activeTab === tab}
+          >
+            <i className={tabIcons[tab]} />
+            {!collapsed && <span>{tab}</span>}
+          </button>
+        ))}
+      </nav>
+      <button
+        className="sidebar__settings"
+        aria-label="Abrir configuración"
+        onClick={onSettingsClick}
+      >
+        <i className="fa-solid fa-gear" />
+        {!collapsed && <span>Configuración</span>}
+      </button>
+    </aside>
+  )
+}
 
 export default Sidebar
 


### PR DESCRIPTION
## Summary
- allow sidebar to collapse and show only icons
- adjust styles for collapsed sidebar width and layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5ce0976f88332b1c66fb37427a06e