### PR TITLE
Show avatar and time in collapsed sidebar

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -13,6 +13,17 @@
   width: 60px;
 }
 
+.sidebar__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.sidebar__time {
+  font-weight: 600;
+}
+
 .sidebar__header {
   display: flex;
   align-items: center;
@@ -37,7 +48,14 @@
   color: inherit;
   cursor: pointer;
   padding: 12px;
-  align-self: flex-end;
+}
+
+.sidebar--collapsed .sidebar__header {
+  justify-content: center;
+}
+
+.sidebar--collapsed .sidebar__name {
+  display: none;
 }
 
 .sidebar__nav {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import './Sidebar.css'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -20,22 +20,31 @@ const tabIcons: Record<Tab, string> = {
 
 const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
   const [collapsed, setCollapsed] = useState(false)
+  const [time, setTime] = useState(new Date())
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const formattedTime = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
-      <button
-        className="sidebar__toggle"
-        aria-label="Alternar menú"
-        onClick={() => setCollapsed(prev => !prev)}
-      >
-        <i className={`fa-solid ${collapsed ? 'fa-chevron-right' : 'fa-chevron-left'}`} />
-      </button>
-      {!collapsed && (
-        <div className="sidebar__header">
-          <div className="sidebar__avatar" />
-          <span className="sidebar__name">GORKA</span>
-        </div>
-      )}
+      <div className="sidebar__top">
+        <span className="sidebar__time">{formattedTime}</span>
+        <button
+          className="sidebar__toggle"
+          aria-label="Alternar menú"
+          onClick={() => setCollapsed(prev => !prev)}
+        >
+          <i className={`fa-solid ${collapsed ? 'fa-chevron-right' : 'fa-chevron-left'}`} />
+        </button>
+      </div>
+      <div className="sidebar__header">
+        <div className="sidebar__avatar" />
+        {!collapsed && <span className="sidebar__name">GORKA</span>}
+      </div>
       <nav className="sidebar__nav" role="tablist">
         {tabs.map(tab => (
           <button


### PR DESCRIPTION
## Summary
- Keep sidebar header visible when collapsed, showing only the avatar
- Add current time display next to the collapse/expand button
- Style sidebar for collapsed state and time bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b5cf9b63808332b0af1296e85ff84c