### PR TITLE
Remove time display from sidebar

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -15,13 +15,9 @@
 
 .sidebar__top {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   padding: 12px 16px;
-}
-
-.sidebar__time {
-  font-weight: 600;
 }
 
 .sidebar__header {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import './Sidebar.css'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -20,19 +20,10 @@ const tabIcons: Record<Tab, string> = {
 
 const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
   const [collapsed, setCollapsed] = useState(false)
-  const [time, setTime] = useState(new Date())
-
-  useEffect(() => {
-    const interval = setInterval(() => setTime(new Date()), 1000)
-    return () => clearInterval(interval)
-  }, [])
-
-  const formattedTime = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
       <div className="sidebar__top">
-        <span className="sidebar__time">{formattedTime}</span>
         <button
           className="sidebar__toggle"
           aria-label="Alternar menú"


### PR DESCRIPTION
## Summary
- remove real-time clock from sidebar menu
- align toggle button to right after time removal

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b5d132afe88332bb20fce8c1c456d1