### PR TITLE
Add scrollspy and reorganize main form layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,12 +12,20 @@ function App() {
   const [msg, setMsg] = useState('cargando...')
   const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [time, setTime] = useState(new Date().toLocaleTimeString())
 
   useEffect(() => {
     fetch(`${API_BASE}/hello`)
       .then(r => r.json())
       .then(d => setMsg(d.message))
       .catch(() => setMsg('Error conectando con el backend'))
+  }, [])
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTime(new Date().toLocaleTimeString())
+    }, 1000)
+    return () => clearInterval(id)
   }, [])
 
   return (
@@ -27,17 +35,49 @@ function App() {
         onTabChange={setActiveTab}
         onSettingsClick={() => setSettingsOpen(true)}
       />
-      <main style={{ flex: 1, fontFamily: 'system-ui, sans-serif', padding: 24, overflow: 'auto' }}>
-        <h1>MP3 Tool</h1>
-        <p>
-          Backend dice: <strong>{msg}</strong>
-        </p>
-        <Suspense fallback={<div>Cargando...</div>}>
-          {activeTab === 'BEATPORT' && <BeatportTab />}
-          {activeTab === '1001TRACKLIST' && <TracklistTab />}
-          {activeTab === 'BAN/UNBAN' && <BanTab />}
-          {activeTab === 'OTROS' && <OtrosTab />}
-        </Suspense>
+      <main
+        style={{
+          flex: 1,
+          fontFamily: 'system-ui, sans-serif',
+          padding: 24,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <nav id="main-breadcrumb" aria-label="breadcrumb">
+          <ol className="breadcrumb mb-3">
+            <li className="breadcrumb-item">
+              <a href="#section-content">Contenido</a>
+            </li>
+            <li className="breadcrumb-item">
+              <a href="#section-info">Información</a>
+            </li>
+            <li className="breadcrumb-item active" aria-current="page">
+              {activeTab}
+            </li>
+          </ol>
+        </nav>
+        <div
+          id="section-content"
+          className="flex-grow-1 overflow-auto"
+          data-bs-spy="scroll"
+          data-bs-target="#main-breadcrumb"
+          tabIndex={0}
+        >
+          <h1>MP3 Tool</h1>
+          <p>
+            Backend dice: <strong>{msg}</strong>
+          </p>
+          <Suspense fallback={<div>Cargando...</div>}>
+            {activeTab === 'BEATPORT' && <BeatportTab />}
+            {activeTab === '1001TRACKLIST' && <TracklistTab />}
+            {activeTab === 'BAN/UNBAN' && <BanTab />}
+            {activeTab === 'OTROS' && <OtrosTab />}
+          </Suspense>
+        </div>
+        <div className="text-end mt-2" id="section-info">
+          {time}
+        </div>
       </main>
       {settingsOpen && (
         <SettingsModal onClose={() => setSettingsOpen(false)} />

--- a/frontend/src/components/ResponsiveTable.tsx
+++ b/frontend/src/components/ResponsiveTable.tsx
@@ -6,7 +6,7 @@ interface ResponsiveTableProps {
 }
 
 const ResponsiveTable = ({ className, children }: PropsWithChildren<ResponsiveTableProps>) => (
-  <div className="responsive-table-wrapper">
+  <div className="responsive-table-wrapper" data-bs-spy="scroll" tabIndex={0}>
     <table className={`responsive-table ${className ?? ''}`.trim()}>
       {children}
     </table>

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -97,7 +97,7 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
             &times;
           </button>
         </div>
-        <div className="settings-tabs">
+        <div className="settings-tabs" id="settings-tabs">
           {(['CHANGELOG', 'QUICK TAG CUSTOM', 'GENERAL'] as Tab[]).map(tab => (
             <button
               key={tab}
@@ -108,7 +108,12 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
             </button>
           ))}
         </div>
-        <div className="settings-content">
+        <div
+          className="settings-content"
+          data-bs-spy="scroll"
+          data-bs-target="#settings-tabs"
+          tabIndex={0}
+        >
           {activeTab === 'CHANGELOG' && (
             <ul className="changelog-list">
               {entries.map(e => (

--- a/frontend/src/tabs/Ban/BanTab.tsx
+++ b/frontend/src/tabs/Ban/BanTab.tsx
@@ -314,6 +314,8 @@ const BanTab = () => {
             </div>
             <ul
               className={`list-group flex-grow-1 overflow-auto ${dragOver === 'ban' ? 'drag-over' : ''}`}
+              data-bs-spy="scroll"
+              tabIndex={0}
               onDragOver={e => e.preventDefault()}
               onDragEnter={() => setDragOver('ban')}
               onDragLeave={() => setDragOver(null)}
@@ -403,6 +405,8 @@ const BanTab = () => {
             </div>
             <ul
               className={`list-group flex-grow-1 overflow-auto ${dragOver === 'unban' ? 'drag-over' : ''}`}
+              data-bs-spy="scroll"
+              tabIndex={0}
               onDragOver={e => e.preventDefault()}
               onDragEnter={() => setDragOver('unban')}
               onDragLeave={() => setDragOver(null)}


### PR DESCRIPTION
## Summary
- use Bootstrap Scrollspy across scrolling areas
- split main content into breadcrumb, scrollable content, and info footer with clock

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5d24e30fc833287d7a255d3bb59a2