### PR TITLE
Add main config toggle and replace home text with start button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, lazy, Suspense } from 'react'
-import { API_BASE } from './config'
+import { useMainConfig } from './MainConfigContext'
 import Sidebar, { type Tab } from './components/Sidebar'
 import SettingsModal from './components/SettingsModal'
 
@@ -9,17 +9,10 @@ const BanTab = lazy(() => import('./tabs/Ban/BanTab'))
 const OtrosTab = lazy(() => import('./tabs/Otros/OtrosTab'))
 
 function App() {
-  const [msg, setMsg] = useState('cargando...')
   const [activeTab, setActiveTab] = useState<Tab>('BEATPORT')
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [time, setTime] = useState(new Date().toLocaleTimeString())
-
-  useEffect(() => {
-    fetch(`${API_BASE}/hello`)
-      .then(r => r.json())
-      .then(d => setMsg(d.message))
-      .catch(() => setMsg('Error conectando con el backend'))
-  }, [])
+  const { config } = useMainConfig()
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -64,14 +57,15 @@ function App() {
           data-bs-target="#main-breadcrumb"
           tabIndex={0}
         >
-          <h1>MP3 Tool</h1>
-          <p>
-            Backend dice: <strong>{msg}</strong>
-          </p>
+          <button type="button" className="btn btn-primary">
+            Iniciar
+          </button>
           <Suspense fallback={<div>Cargando...</div>}>
             {activeTab === 'BEATPORT' && <BeatportTab />}
             {activeTab === '1001TRACKLIST' && <TracklistTab />}
-            {activeTab === 'BAN/UNBAN' && <BanTab />}
+            {config.banScreenEnabled && activeTab === 'BAN/UNBAN' && (
+              <BanTab />
+            )}
             {activeTab === 'OTROS' && <OtrosTab />}
           </Suspense>
         </div>

--- a/frontend/src/MainConfigContext.tsx
+++ b/frontend/src/MainConfigContext.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+import { defaultMainConfig, type MainConfig } from './main.config'
+
+interface MainConfigContextValue {
+  config: MainConfig
+  setConfig: (config: MainConfig) => void
+}
+
+const MainConfigContext = createContext<MainConfigContextValue | undefined>(
+  undefined,
+)
+
+export const MainConfigProvider = ({ children }: { children: ReactNode }) => {
+  const [config, setConfigState] = useState<MainConfig>(defaultMainConfig)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('main.config')
+    if (stored) {
+      try {
+        setConfigState({ ...defaultMainConfig, ...JSON.parse(stored) })
+      } catch {
+        setConfigState(defaultMainConfig)
+      }
+    }
+  }, [])
+
+  const setConfig = (cfg: MainConfig) => {
+    setConfigState(cfg)
+    localStorage.setItem('main.config', JSON.stringify(cfg))
+  }
+
+  return (
+    <MainConfigContext.Provider value={{ config, setConfig }}>
+      {children}
+    </MainConfigContext.Provider>
+  )
+}
+
+export const useMainConfig = () => {
+  const ctx = useContext(MainConfigContext)
+  if (!ctx) {
+    throw new Error('useMainConfig must be used within a MainConfigProvider')
+  }
+  return ctx
+}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import './SettingsModal.css'
 import { useTheme } from '../theme/ThemeContext'
+import { useMainConfig } from '../MainConfigContext'
 
 interface ChangelogEntry {
   hash: string
@@ -19,6 +20,7 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
   const [entries, setEntries] = useState<ChangelogEntry[]>([])
   const [isClosing, setIsClosing] = useState(false)
   const { theme, setTheme } = useTheme()
+  const { config, setConfig } = useMainConfig()
   const openerRef = useRef<HTMLElement | null>(
     document.activeElement instanceof HTMLElement ? document.activeElement : null
   )
@@ -126,16 +128,30 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
           )}
           {activeTab === 'QUICK TAG CUSTOM' && <div className="placeholder">Coming soon...</div>}
           {activeTab === 'GENERAL' && (
-            <div className="theme-toggle">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={theme === 'dark'}
-                  onChange={e => setTheme(e.target.checked ? 'dark' : 'light')}
-                />
-                Dark mode
-              </label>
-            </div>
+            <>
+              <div className="theme-toggle">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={theme === 'dark'}
+                    onChange={e => setTheme(e.target.checked ? 'dark' : 'light')}
+                  />
+                  Dark mode
+                </label>
+              </div>
+              <div className="theme-toggle">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={config.banScreenEnabled}
+                    onChange={e =>
+                      setConfig({ ...config, banScreenEnabled: e.target.checked })
+                    }
+                  />
+                  Habilitar Ban/Unban
+                </label>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useMainConfig } from '../MainConfigContext'
 import './Sidebar.css'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -9,8 +10,6 @@ interface SidebarProps {
   onSettingsClick: () => void
 }
 
-const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
-
 const tabIcons: Record<Tab, string> = {
   BEATPORT: 'fa-solid fa-music',
   '1001TRACKLIST': 'fa-solid fa-list',
@@ -20,6 +19,10 @@ const tabIcons: Record<Tab, string> = {
 
 const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
   const [collapsed, setCollapsed] = useState(false)
+  const { config } = useMainConfig()
+  const tabs: Tab[] = config.banScreenEnabled
+    ? ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
+    : ['BEATPORT', '1001TRACKLIST', 'OTROS']
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>

--- a/frontend/src/main.config.ts
+++ b/frontend/src/main.config.ts
@@ -1,0 +1,7 @@
+export interface MainConfig {
+  banScreenEnabled: boolean;
+}
+
+export const defaultMainConfig: MainConfig = {
+  banScreenEnabled: true,
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,11 +6,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from './theme/ThemeContext'
+import { MainConfigProvider } from './MainConfigContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <MainConfigProvider>
+        <App />
+      </MainConfigProvider>
     </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add main configuration context and file to enable or disable Ban/Unban feature
- expose feature toggle in settings alongside dark mode switch
- replace main page text with Bootstrap "Iniciar" button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5d5a1ab3083329cfdb35abbff6ab0