### PR TITLE
feat: check ban config on start

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,10 @@ function App() {
     return () => clearInterval(id)
   }, [])
 
+  const handleStart = () => {
+    alert(config.banScreenEnabled ? 'OK' : 'NO OK')
+  }
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <Sidebar
@@ -57,15 +61,17 @@ function App() {
           data-bs-target="#main-breadcrumb"
           tabIndex={0}
         >
-          <button type="button" className="btn btn-primary">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleStart}
+          >
             Iniciar
           </button>
           <Suspense fallback={<div>Cargando...</div>}>
             {activeTab === 'BEATPORT' && <BeatportTab />}
             {activeTab === '1001TRACKLIST' && <TracklistTab />}
-            {config.banScreenEnabled && activeTab === 'BAN/UNBAN' && (
-              <BanTab />
-            )}
+            {activeTab === 'BAN/UNBAN' && <BanTab />}
             {activeTab === 'OTROS' && <OtrosTab />}
           </Suspense>
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useMainConfig } from '../MainConfigContext'
 import './Sidebar.css'
 
 export type Tab = 'BEATPORT' | '1001TRACKLIST' | 'BAN/UNBAN' | 'OTROS'
@@ -19,10 +18,7 @@ const tabIcons: Record<Tab, string> = {
 
 const Sidebar = ({ activeTab, onTabChange, onSettingsClick }: SidebarProps) => {
   const [collapsed, setCollapsed] = useState(false)
-  const { config } = useMainConfig()
-  const tabs: Tab[] = config.banScreenEnabled
-    ? ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
-    : ['BEATPORT', '1001TRACKLIST', 'OTROS']
+  const tabs: Tab[] = ['BEATPORT', '1001TRACKLIST', 'BAN/UNBAN', 'OTROS']
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>


### PR DESCRIPTION
## Summary
- run start button logic based on main config
- always show Ban/Unban tab in sidebar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5e6e0264c833282489a439da0718c