### PR TITLE
Trigger BAN/UNBAN processing on start

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, lazy, Suspense } from 'react'
 import { useMainConfig } from './MainConfigContext'
 import Sidebar, { type Tab } from './components/Sidebar'
 import SettingsModal from './components/SettingsModal'
+import { apiFetch } from './utils/api'
 
 const BeatportTab = lazy(() => import('./tabs/Beatport/BeatportTab'))
 const TracklistTab = lazy(() => import('./tabs/Tracklist/TracklistTab'))
@@ -21,8 +22,24 @@ function App() {
     return () => clearInterval(id)
   }, [])
 
-  const handleStart = () => {
-    alert(config.banScreenEnabled ? 'OK' : 'NO OK')
+  const handleStart = async () => {
+    if (!config.banScreenEnabled) {
+      return
+    }
+    try {
+      const res = await apiFetch('/tracklists/start', {
+        method: 'POST',
+        body: JSON.stringify({ ban_unban_active: true }),
+      })
+      const processed = res.processed || { ban: [], unban: [] }
+      if (processed.ban.length === 0 && processed.unban.length === 0) {
+        alert('No hay carpetas para procesar')
+      } else {
+        alert('Proceso BAN/UNBAN completado')
+      }
+    } catch {
+      alert('Error al iniciar el proceso')
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Call backend `/tracklists/start` when the Start button is pressed and BAN/UNBAN is enabled
- Show alerts when no folders are processed or when processing completes

## Testing
- `npm test`
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5ee6b6e6c8332a1d5fecd66c47c79